### PR TITLE
Add test coverage to xk6-redis

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.43.0
+# v1.47.2
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m
@@ -29,6 +29,9 @@ issues:
      text: "does not use range value in test Run"
 
 linters-settings:
+  nolintlint:
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    allow-leading-space: false
   exhaustive:
     default-signifies-exhaustive: true
   govet:
@@ -45,6 +48,13 @@ linters-settings:
   funlen:
     lines: 80
     statements: 60
+  goheader:
+    template-path: ".license-template"
+    values:
+      const:
+        year: "2022"
+      regexp:
+        year-range: (\d\d\d\d|{{year}})
 
 linters:
   enable-all: true
@@ -68,7 +78,14 @@ linters:
   - scopelint # deprecated, replaced by exportloopref
   - wrapcheck # a little bit too much for k6, maybe after https://github.com/tomarrell/wrapcheck/issues/2 is fixed
   - golint # this linter is deprecated
-  - varnamelen # disabled before the final decision in (https://github.com/grafana/k6/pull/2323)
+  - varnamelen
   - ireturn
   - tagliatelle
+  - exhaustruct
+  - execinquery
+  - maintidx
+  - grouper
+  - decorder
+  - nonamedreturns
+  - nosnakecase
   fast: false

--- a/client.go
+++ b/client.go
@@ -1060,7 +1060,7 @@ func (c *Client) isSupportedType(offset int, args ...interface{}) error {
 	for idx, arg := range args {
 		switch arg.(type) {
 		case string, int, int64, float64, bool:
-			return nil
+			continue
 		default:
 			return fmt.Errorf("unsupported type: %T for argument at index: %d", arg, idx+offset)
 		}

--- a/client.go
+++ b/client.go
@@ -19,10 +19,12 @@ type Client struct {
 }
 
 // Set the given key with the given value.
+//
+// The value for `expiration` is interpreted as seconds.
 func (c *Client) Set(key string, value interface{}, expiration int) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -49,7 +51,7 @@ func (c *Client) Set(key string, value interface{}, expiration int) *goja.Promis
 func (c *Client) Get(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -71,7 +73,7 @@ func (c *Client) Get(key string) *goja.Promise {
 func (c *Client) GetSet(key string, value interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -98,7 +100,7 @@ func (c *Client) GetSet(key string, value interface{}) *goja.Promise {
 func (c *Client) Del(keys ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -120,7 +122,7 @@ func (c *Client) Del(keys ...string) *goja.Promise {
 func (c *Client) GetDel(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -144,7 +146,7 @@ func (c *Client) GetDel(key string) *goja.Promise {
 func (c *Client) Exists(keys ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -169,7 +171,7 @@ func (c *Client) Exists(keys ...string) *goja.Promise {
 func (c *Client) Incr(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -194,7 +196,7 @@ func (c *Client) Incr(key string) *goja.Promise {
 func (c *Client) IncrBy(key string, increment int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -219,7 +221,7 @@ func (c *Client) IncrBy(key string, increment int64) *goja.Promise {
 func (c *Client) Decr(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -244,7 +246,7 @@ func (c *Client) Decr(key string) *goja.Promise {
 func (c *Client) DecrBy(key string, decrement int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -266,7 +268,7 @@ func (c *Client) DecrBy(key string, decrement int64) *goja.Promise {
 func (c *Client) RandomKey() *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -288,7 +290,7 @@ func (c *Client) RandomKey() *goja.Promise {
 func (c *Client) Mget(keys ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -313,7 +315,7 @@ func (c *Client) Mget(keys ...string) *goja.Promise {
 func (c *Client) Expire(key string, seconds int) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -336,7 +338,7 @@ func (c *Client) Expire(key string, seconds int) *goja.Promise {
 func (c *Client) Ttl(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -358,7 +360,7 @@ func (c *Client) Ttl(key string) *goja.Promise {
 func (c *Client) Persist(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -383,7 +385,7 @@ func (c *Client) Persist(key string) *goja.Promise {
 func (c *Client) Lpush(key string, values ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -412,7 +414,7 @@ func (c *Client) Lpush(key string, values ...interface{}) *goja.Promise {
 func (c *Client) Rpush(key string, values ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -439,7 +441,7 @@ func (c *Client) Rpush(key string, values ...interface{}) *goja.Promise {
 func (c *Client) Lpop(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -461,7 +463,7 @@ func (c *Client) Lpop(key string) *goja.Promise {
 func (c *Client) Rpop(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -486,7 +488,7 @@ func (c *Client) Rpop(key string) *goja.Promise {
 func (c *Client) Lrange(key string, start, stop int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -510,7 +512,7 @@ func (c *Client) Lrange(key string, start, stop int64) *goja.Promise {
 func (c *Client) Lindex(key string, index int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -532,7 +534,7 @@ func (c *Client) Lindex(key string, index int64) *goja.Promise {
 func (c *Client) Lset(key string, index int64, element string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -557,7 +559,7 @@ func (c *Client) Lset(key string, index int64, element string) *goja.Promise {
 func (c *Client) Lrem(key string, count int64, value string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -580,7 +582,7 @@ func (c *Client) Lrem(key string, count int64, value string) *goja.Promise {
 func (c *Client) Llen(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -604,7 +606,7 @@ func (c *Client) Llen(key string) *goja.Promise {
 func (c *Client) Hset(key string, field string, value interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -634,7 +636,7 @@ func (c *Client) Hset(key string, field string, value interface{}) *goja.Promise
 func (c *Client) Hsetnx(key, field, value string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -656,7 +658,7 @@ func (c *Client) Hsetnx(key, field, value string) *goja.Promise {
 func (c *Client) Hget(key, field string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -678,7 +680,7 @@ func (c *Client) Hget(key, field string) *goja.Promise {
 func (c *Client) Hdel(key string, fields ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -700,7 +702,7 @@ func (c *Client) Hdel(key string, fields ...string) *goja.Promise {
 func (c *Client) Hgetall(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -722,7 +724,7 @@ func (c *Client) Hgetall(key string) *goja.Promise {
 func (c *Client) Hkeys(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -744,7 +746,7 @@ func (c *Client) Hkeys(key string) *goja.Promise {
 func (c *Client) Hvals(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -766,7 +768,7 @@ func (c *Client) Hvals(key string) *goja.Promise {
 func (c *Client) Hlen(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -791,7 +793,7 @@ func (c *Client) Hlen(key string) *goja.Promise {
 func (c *Client) Hincrby(key, field string, increment int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -815,7 +817,7 @@ func (c *Client) Hincrby(key, field string, increment int64) *goja.Promise {
 func (c *Client) Sadd(key string, members ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -844,7 +846,7 @@ func (c *Client) Sadd(key string, members ...interface{}) *goja.Promise {
 func (c *Client) Srem(key string, members ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -871,7 +873,7 @@ func (c *Client) Srem(key string, members ...interface{}) *goja.Promise {
 func (c *Client) Sismember(key string, member interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -898,7 +900,7 @@ func (c *Client) Sismember(key string, member interface{}) *goja.Promise {
 func (c *Client) Smembers(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -920,7 +922,7 @@ func (c *Client) Smembers(key string) *goja.Promise {
 func (c *Client) Srandmember(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -942,7 +944,7 @@ func (c *Client) Srandmember(key string) *goja.Promise {
 func (c *Client) Spop(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -968,7 +970,7 @@ func (c *Client) SendCommand(command string, args ...interface{}) *goja.Promise 
 
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.connect(); err != nil {
+	if err := c.Connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -1014,9 +1016,9 @@ func (c *Client) makeHandledPromise() (*goja.Promise, func(interface{}), func(in
 		}
 }
 
-// connect establishes the client's connection to the target
+// Connect establishes the client's connection to the target
 // redis instance(s).
-func (c *Client) connect() error {
+func (c *Client) Connect() error {
 	// A nil VU state indicates we are in the init context.
 	// As a general convention, k6 should not perform IO in the
 	// init context. Thus, the Connect method will error if
@@ -1026,6 +1028,8 @@ func (c *Client) connect() error {
 		return common.NewInitContextError("connecting to a redis server in the init context is not supported")
 	}
 
+	// If the redisClient is already instantiated, it is safe
+	// to assume that the connection is already established.
 	if c.redisClient == nil {
 		// If k6 has a TLSConfig set in its state, use
 		// it has redis' client TLSConfig too.
@@ -1041,6 +1045,35 @@ func (c *Client) connect() error {
 	}
 
 	return nil
+}
+
+// Close closes the client's connection to the target redis instance(s).
+func (c *Client) Close() error {
+	// A nil VU state indicates we are in the init context.
+	// As a general convention, k6 should not perform IO in the
+	// init context. As the Close method is symmetric to the Connect
+	// method, it will error if called in the init context; even though
+	// calling doesn't effectively perform any IO.
+	if c.vu.State() == nil {
+		return common.NewInitContextError("closing a redis connection in the init context is not supported")
+	}
+
+	// The redisClient attribute is set when redis' client dialer,
+	// TLSConfig and options are set: allowing the redis client to
+	// communicate with the outside. Setting it to nil will cause
+	// the Client to not be able to communicate with the outside.
+	if c.redisClient != nil {
+		err := c.redisClient.Close()
+		c.redisClient = nil
+		return err
+	}
+
+	return nil
+}
+
+// IsConnected returns true if the client is connected to redis.
+func (c *Client) IsConnected() bool {
+	return c.redisClient != nil
 }
 
 // isSupportedType returns whether the provided arguments are of a type

--- a/client.go
+++ b/client.go
@@ -20,11 +20,13 @@ type Client struct {
 
 // Set the given key with the given value.
 //
+// If the provided value is not a supported type, the promise is rejected with an error.
+//
 // The value for `expiration` is interpreted as seconds.
 func (c *Client) Set(key string, value interface{}, expiration int) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -48,10 +50,14 @@ func (c *Client) Set(key string, value interface{}, expiration int) *goja.Promis
 }
 
 // Get returns the value for the given key.
+//
+// If the key does not exist, the promise is rejected with an error.
+//
+// If the key does not exist, the promise is rejected with an error.
 func (c *Client) Get(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -70,10 +76,12 @@ func (c *Client) Get(key string) *goja.Promise {
 }
 
 // GetSet sets the value of key to value and returns the old value stored
+//
+// If the provided value is not a supported type, the promise is rejected with an error.
 func (c *Client) GetSet(key string, value interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -100,7 +108,7 @@ func (c *Client) GetSet(key string, value interface{}) *goja.Promise {
 func (c *Client) Del(keys ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -119,10 +127,12 @@ func (c *Client) Del(keys ...string) *goja.Promise {
 }
 
 // GetDel gets the value of key and deletes the key.
+//
+// If the key does not exist, the promise is rejected with an error.
 func (c *Client) GetDel(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -146,7 +156,7 @@ func (c *Client) GetDel(key string) *goja.Promise {
 func (c *Client) Exists(keys ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -171,7 +181,7 @@ func (c *Client) Exists(keys ...string) *goja.Promise {
 func (c *Client) Incr(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -196,7 +206,7 @@ func (c *Client) Incr(key string) *goja.Promise {
 func (c *Client) IncrBy(key string, increment int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -221,7 +231,7 @@ func (c *Client) IncrBy(key string, increment int64) *goja.Promise {
 func (c *Client) Decr(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -246,7 +256,7 @@ func (c *Client) Decr(key string) *goja.Promise {
 func (c *Client) DecrBy(key string, decrement int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -265,10 +275,12 @@ func (c *Client) DecrBy(key string, decrement int64) *goja.Promise {
 }
 
 // RandomKey returns a random key.
+//
+// If the database is empty, the promise is rejected with an error.
 func (c *Client) RandomKey() *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -290,7 +302,7 @@ func (c *Client) RandomKey() *goja.Promise {
 func (c *Client) Mget(keys ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -315,7 +327,7 @@ func (c *Client) Mget(keys ...string) *goja.Promise {
 func (c *Client) Expire(key string, seconds int) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -334,11 +346,11 @@ func (c *Client) Expire(key string, seconds int) *goja.Promise {
 }
 
 // Ttl returns the remaining time to live of a key that has a timeout.
-// nolint:stylecheck,revive
+//nolint:revive,stylecheck
 func (c *Client) Ttl(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -360,7 +372,7 @@ func (c *Client) Ttl(key string) *goja.Promise {
 func (c *Client) Persist(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -385,7 +397,7 @@ func (c *Client) Persist(key string) *goja.Promise {
 func (c *Client) Lpush(key string, values ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -414,7 +426,7 @@ func (c *Client) Lpush(key string, values ...interface{}) *goja.Promise {
 func (c *Client) Rpush(key string, values ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -438,10 +450,13 @@ func (c *Client) Rpush(key string, values ...interface{}) *goja.Promise {
 }
 
 // Lpop removes and returns the first element of the list stored at `key`.
+//
+// If the list does not exist, this command rejects the promise with an error.
 func (c *Client) Lpop(key string) *goja.Promise {
+	// TODO: redis supports indicating the amount of values to pop
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -460,10 +475,13 @@ func (c *Client) Lpop(key string) *goja.Promise {
 }
 
 // Rpop removes and returns the last element of the list stored at `key`.
+//
+// If the list does not exist, this command rejects the promise with an error.
 func (c *Client) Rpop(key string) *goja.Promise {
+	// TODO: redis supports indicating the amount of values to pop
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -488,7 +506,7 @@ func (c *Client) Rpop(key string) *goja.Promise {
 func (c *Client) Lrange(key string, start, stop int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -509,10 +527,12 @@ func (c *Client) Lrange(key string, start, stop int64) *goja.Promise {
 // Lindex returns the specified element of the list stored at `key`.
 // The index is zero-based. Negative indices can be used to designate
 // elements starting at the tail of the list.
+//
+// If the list does not exist, this command rejects the promise with an error.
 func (c *Client) Lindex(key string, index int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -531,10 +551,12 @@ func (c *Client) Lindex(key string, index int64) *goja.Promise {
 }
 
 // Lset sets the list element at `index` to `element`.
+//
+// If the list does not exist, this command rejects the promise with an error.
 func (c *Client) Lset(key string, index int64, element string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -556,10 +578,12 @@ func (c *Client) Lset(key string, index int64, element string) *goja.Promise {
 // at `key`. If `count` is positive, elements are removed from the beginning of the list.
 // If `count` is negative, elements are removed from the end of the list.
 // If `count` is zero, all elements matching `value` are removed.
+//
+// If the list does not exist, this command rejects the promise with an error.
 func (c *Client) Lrem(key string, count int64, value string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -579,10 +603,12 @@ func (c *Client) Lrem(key string, count int64, value string) *goja.Promise {
 
 // Llen returns the length of the list stored at `key`. If `key`
 // does not exist, it is interpreted as an empty list and 0 is returned.
+//
+// If the list does not exist, this command rejects the promise with an error.
 func (c *Client) Llen(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -603,10 +629,12 @@ func (c *Client) Llen(key string) *goja.Promise {
 // Hset sets the specified field in the hash stored at `key` to `value`.
 // If the `key` does not exist, a new key holding a hash is created.
 // If `field` already exists in the hash, it is overwritten.
+//
+// If the hash does not exist, this command rejects the promise with an error.
 func (c *Client) Hset(key string, field string, value interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -636,7 +664,7 @@ func (c *Client) Hset(key string, field string, value interface{}) *goja.Promise
 func (c *Client) Hsetnx(key, field, value string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -655,10 +683,12 @@ func (c *Client) Hsetnx(key, field, value string) *goja.Promise {
 }
 
 // Hget returns the value associated with `field` in the hash stored at `key`.
+//
+// If the hash does not exist, this command rejects the promise with an error.
 func (c *Client) Hget(key, field string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -680,7 +710,7 @@ func (c *Client) Hget(key, field string) *goja.Promise {
 func (c *Client) Hdel(key string, fields ...string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -699,10 +729,12 @@ func (c *Client) Hdel(key string, fields ...string) *goja.Promise {
 }
 
 // Hgetall returns all fields and values of the hash stored at `key`.
+//
+// If the hash does not exist, this command rejects the promise with an error.
 func (c *Client) Hgetall(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -721,10 +753,12 @@ func (c *Client) Hgetall(key string) *goja.Promise {
 }
 
 // Hkeys returns all fields of the hash stored at `key`.
+//
+// If the hash does not exist, this command rejects the promise with an error.
 func (c *Client) Hkeys(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -743,10 +777,12 @@ func (c *Client) Hkeys(key string) *goja.Promise {
 }
 
 // Hvals returns all values of the hash stored at `key`.
+//
+// If the hash does not exist, this command rejects the promise with an error.
 func (c *Client) Hvals(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -765,10 +801,12 @@ func (c *Client) Hvals(key string) *goja.Promise {
 }
 
 // Hlen returns the number of fields in the hash stored at `key`.
+//
+// If the hash does not exist, this command rejects the promise with an error.
 func (c *Client) Hlen(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -793,7 +831,7 @@ func (c *Client) Hlen(key string) *goja.Promise {
 func (c *Client) Hincrby(key, field string, increment int64) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -817,7 +855,7 @@ func (c *Client) Hincrby(key, field string, increment int64) *goja.Promise {
 func (c *Client) Sadd(key string, members ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -846,7 +884,7 @@ func (c *Client) Sadd(key string, members ...interface{}) *goja.Promise {
 func (c *Client) Srem(key string, members ...interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -873,7 +911,7 @@ func (c *Client) Srem(key string, members ...interface{}) *goja.Promise {
 func (c *Client) Sismember(key string, member interface{}) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -900,7 +938,7 @@ func (c *Client) Sismember(key string, member interface{}) *goja.Promise {
 func (c *Client) Smembers(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -919,10 +957,12 @@ func (c *Client) Smembers(key string) *goja.Promise {
 }
 
 // Srandmember returns a random element from the set value stored at key.
+//
+// If the set does not exist, the promise is rejected with an error.
 func (c *Client) Srandmember(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -941,10 +981,12 @@ func (c *Client) Srandmember(key string) *goja.Promise {
 }
 
 // Spop removes and returns a random element from the set value stored at key.
+//
+// If the set does not exist, the promise is rejected with an error.
 func (c *Client) Spop(key string) *goja.Promise {
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -970,7 +1012,7 @@ func (c *Client) SendCommand(command string, args ...interface{}) *goja.Promise 
 
 	promise, resolve, reject := c.makeHandledPromise()
 
-	if err := c.Connect(); err != nil {
+	if err := c.connect(); err != nil {
 		reject(err)
 		return promise
 	}
@@ -1016,9 +1058,9 @@ func (c *Client) makeHandledPromise() (*goja.Promise, func(interface{}), func(in
 		}
 }
 
-// Connect establishes the client's connection to the target
+// connect establishes the client's connection to the target
 // redis instance(s).
-func (c *Client) Connect() error {
+func (c *Client) connect() error {
 	// A nil VU state indicates we are in the init context.
 	// As a general convention, k6 should not perform IO in the
 	// init context. Thus, the Connect method will error if
@@ -1030,43 +1072,23 @@ func (c *Client) Connect() error {
 
 	// If the redisClient is already instantiated, it is safe
 	// to assume that the connection is already established.
-	if c.redisClient == nil {
-		// If k6 has a TLSConfig set in its state, use
-		// it has redis' client TLSConfig too.
-		if vuState.TLSConfig != nil {
-			c.redisOptions.TLSConfig = vuState.TLSConfig
-		}
-
-		// use k6's lib.DialerContexter function has redis'
-		// client Dialer
-		c.redisOptions.Dialer = vuState.Dialer.DialContext
-
-		c.redisClient = redis.NewUniversalClient(c.redisOptions)
-	}
-
-	return nil
-}
-
-// Close closes the client's connection to the target redis instance(s).
-func (c *Client) Close() error {
-	// A nil VU state indicates we are in the init context.
-	// As a general convention, k6 should not perform IO in the
-	// init context. As the Close method is symmetric to the Connect
-	// method, it will error if called in the init context; even though
-	// calling doesn't effectively perform any IO.
-	if c.vu.State() == nil {
-		return common.NewInitContextError("closing a redis connection in the init context is not supported")
-	}
-
-	// The redisClient attribute is set when redis' client dialer,
-	// TLSConfig and options are set: allowing the redis client to
-	// communicate with the outside. Setting it to nil will cause
-	// the Client to not be able to communicate with the outside.
 	if c.redisClient != nil {
-		err := c.redisClient.Close()
-		c.redisClient = nil
-		return err
+		return nil
 	}
+
+	// If k6 has a TLSConfig set in its state, use
+	// it has redis' client TLSConfig too.
+	if vuState.TLSConfig != nil {
+		c.redisOptions.TLSConfig = vuState.TLSConfig
+	}
+
+	// use k6's lib.DialerContexter function has redis'
+	// client Dialer
+	c.redisOptions.Dialer = vuState.Dialer.DialContext
+
+	// Replace the internal redis client instance with a new
+	// one using our custom options.
+	c.redisClient = redis.NewUniversalClient(c.redisOptions)
 
 	return nil
 }
@@ -1095,7 +1117,9 @@ func (c *Client) isSupportedType(offset int, args ...interface{}) error {
 		case string, int, int64, float64, bool:
 			continue
 		default:
-			return fmt.Errorf("unsupported type: %T for argument at index: %d", arg, idx+offset)
+			return fmt.Errorf(
+				"unsupported type provided for argument at index %d, "+
+					"supported types are string, number, and boolean", idx+offset)
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -2,10 +2,11 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,140 +19,2292 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
-func TestClientConnect(t *testing.T) {
+func TestClientSet(t *testing.T) {
 	t.Parallel()
 
-	t.Run("connecting in the init context throws", func(t *testing.T) {
-		t.Parallel()
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("SET", func(c *Connection, args []string) {
+		if len(args) <= 2 && len(args) > 4 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'GET' command"))
+			return
+		}
 
-		ts := newInitContextTestSetup(t) // setup to execute code in the init context
+		switch args[0] {
+		case "existing_key", "non_existing_key": //nolint:goconst
+			c.WriteOK()
+		case "expires":
+			if len(args) != 4 && args[2] != "EX" && args[3] != "0" {
+				c.WriteError(errors.New("ERR unexpected number of arguments for 'SET' command"))
+			}
+			c.WriteOK()
+		}
+	})
 
-		gotScriptErr := ts.ev.Start(func() error {
-			_, err := ts.rt.RunString(fmt.Sprintf(`
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
 			const redis = new Client({
 				addrs: new Array("%s"),
 			});
 
-			redis.connect();
-		`, ts.redis.Addr()))
+			redis.set("existing_key", "new_value")
+				.then(res => { if (res !== "OK") { throw 'unexpected value for set result: ' + res } })
+				.then(() => redis.set("non_existing_key", "some_value"))
+				.then(res => { if (res !== "OK") { throw 'unexpected value for set result: ' + res } })
+				.then(() => redis.set("expires", "expired", 10))
+				.then(res => { if (res !== "OK") { throw 'unexpected value for set result: ' + res } })
+				.then(() => redis.set("unsupported_type", new Array("unsupported")))
+				.then(
+					res => { throw 'expected to fail setting unsupported type' },
+					err => { if (!err.error().startsWith('unsupported type')) { throw 'unexpected error: ' + err } }
+				)
+		`, rs.Addr()))
 
-			return err
-		})
-
-		assert.Error(t, gotScriptErr)
-		assert.Contains(t, gotScriptErr.Error(), "connecting to a redis server in the init context is not supported")
+		return err
 	})
 
-	t.Run("connecting in the main context works", func(t *testing.T) {
-		t.Parallel()
-
-		ts := newTestSetup(t) // Setup to execute code in the main context
-
-		gotScriptErr := ts.ev.Start(func() error {
-			_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
-
-			redis.connect();
-			`, ts.redis.Addr()))
-
-			return err
-		})
-
-		assert.NoError(t, gotScriptErr)
-	})
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SET", "existing_key", "new_value"},
+		{"SET", "non_existing_key", "some_value"},
+		{"SET", "expires", "expired", "ex", "10"},
+	}, rs.GotCommands())
 }
 
-func TestClientClose(t *testing.T) {
+func TestClientGet(t *testing.T) {
 	t.Parallel()
 
-	t.Run("closing in the init context throws", func(t *testing.T) {
-		t.Parallel()
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("GET", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'GET' command"))
+			return
+		}
 
-		ts := newInitContextTestSetup(t) // setup to execute code in the init context
+		switch args[0] {
+		case "existing_key":
+			c.WriteBulkString("old_value")
+		case "non_existing_key":
+			c.WriteNull()
+		}
+	})
 
-		gotScriptErr := ts.ev.Start(func() error {
-			_, err := ts.rt.RunString(fmt.Sprintf(`
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
 			const redis = new Client({
 				addrs: new Array("%s"),
 			});
 
-			redis.close();
-		`, ts.redis.Addr()))
+			redis.get("existing_key")
+				.then(res => { if (res !== "old_value") { throw 'unexpected value for get result: ' + res } })
+				.then(() => redis.get("non_existing_key"))
+				.then(
+					res => { throw 'expected to fail getting non-existing key from redis' },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error: ' + err } }
+				)
+		`, rs.Addr()))
 
-			return err
-		})
-
-		assert.Error(t, gotScriptErr)
-		assert.Contains(t, gotScriptErr.Error(), "closing a redis connection in the init context is not supported")
+		return err
 	})
 
-	t.Run("closing a connected client in the main context", func(t *testing.T) {
-		t.Parallel()
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"GET", "existing_key"},
+		{"GET", "non_existing_key"},
+	}, rs.GotCommands())
+}
 
-		ts := newTestSetup(t) // Setup to execute code in the main context
+func TestClientGetSet(t *testing.T) {
+	t.Parallel()
 
-		gotScriptErr := ts.ev.Start(func() error {
-			_, err := ts.rt.RunString(fmt.Sprintf(`
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("GETSET", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'GETSET' command"))
+			return
+		}
+
+		switch args[0] {
+		case "existing_key":
+			c.WriteBulkString("old_value")
+		case "non_existing_key":
+			c.WriteOK()
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
 			const redis = new Client({
 				addrs: new Array("%s"),
 			});
 
-			redis.connect();
-			redis.close();
+			redis.getSet("existing_key", "new_value")
+				.then(res => { if (res !== "old_value") { throw 'unexpected value for getSet result: ' + res } })
+				.then(() => redis.getSet("non_existing_key", "some_value"))
+				.then(res => { if (res !== "OK") { throw 'unexpected value for getSet result: ' + res } })
+				.then(() => redis.getSet("unsupported_type", new Array("unsupported")))
+				.then(
+					res => { throw 'unexpectedly resolve getset unsupported type' },
+					err => { if (!err.error().startsWith('unsupported type')) { throw 'unexpected error: ' + err } }
+				)
+		`, rs.Addr()))
 
-			if (redis.isConnected() === true) {
-				throw new Error("redis client is still connected");
-			}
-			`, ts.redis.Addr()))
-
-			return err
-		})
-
-		assert.NoError(t, gotScriptErr)
+		return err
 	})
 
-	t.Run("closing an already closed client ", func(t *testing.T) {
-		t.Parallel()
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"GETSET", "existing_key", "new_value"},
+		{"GETSET", "non_existing_key", "some_value"},
+	}, rs.GotCommands())
+}
 
-		ts := newTestSetup(t) // Setup to execute code in the main context
+func TestClientDel(t *testing.T) {
+	t.Parallel()
 
-		gotScriptErr := ts.ev.Start(func() error {
-			_, err := ts.rt.RunString(fmt.Sprintf(`
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("DEL", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'DEL' command"))
+			return
+		}
+
+		c.WriteInteger(2)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
 			const redis = new Client({
 				addrs: new Array("%s"),
 			});
 
-			redis.close();
-			`, ts.redis.Addr()))
+			redis.del("key1", "key2", "nonexisting_key")
+				.then(res => { if (res !== 2) { throw 'unexpected value for del result: ' + res } })
+		`, rs.Addr()))
 
-			return err
-		})
-
-		assert.NoError(t, gotScriptErr)
+		return err
 	})
 
-	t.Run("double closing a client ", func(t *testing.T) {
-		t.Parallel()
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 1, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"DEL", "key1", "key2", "nonexisting_key"},
+	}, rs.GotCommands())
+}
 
-		ts := newTestSetup(t) // Setup to execute code in the main context
+func TestClientGetDel(t *testing.T) {
+	t.Parallel()
 
-		gotScriptErr := ts.ev.Start(func() error {
-			_, err := ts.rt.RunString(fmt.Sprintf(`
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("GETDEL", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'GETDEL' command"))
+			return
+		}
+
+		switch args[0] {
+		case "existing_key":
+			c.WriteBulkString("old_value")
+		case "non_existing_key":
+			c.WriteNull()
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
 			const redis = new Client({
 				addrs: new Array("%s"),
 			});
 
-			redis.close();
-			redis.close();
-			`, ts.redis.Addr()))
+			redis.getDel("existing_key")
+				.then(res => { if (res !== "old_value") { throw 'unexpected value for getDel result: ' + res } })
+				.then(() => redis.getDel("non_existing_key"))
+				.then(
+					res => { if (res !== null) { throw 'unexpected value for getSet result: ' + res } },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error: ' + err } }
+				)
+		`, rs.Addr()))
 
-			return err
-		})
-
-		assert.NoError(t, gotScriptErr)
+		return err
 	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"GETDEL", "existing_key"},
+		{"GETDEL", "non_existing_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientExists(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("EXISTS", func(c *Connection, args []string) {
+		if len(args) == 0 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'EXISTS' command"))
+			return
+		}
+
+		c.WriteInteger(1)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.exists("existing_key", "nonexisting_key")
+				.then(res => { if (res !== 1) { throw 'unexpected value for exists result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 1, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"EXISTS", "existing_key", "nonexisting_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientIncr(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("INCR", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'INCR' command"))
+			return
+		}
+
+		existingValue := 10
+
+		switch args[0] {
+		case "existing_key":
+			c.WriteInteger(existingValue + 1)
+		case "non_existing_key":
+			c.WriteInteger(0 + 1)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.incr("existing_key")
+				.then(res => { if (res !== 11) { throw 'unexpected value for existing key incr result: ' + res } })
+				.then(() => redis.incr("non_existing_key"))
+				.then(res => { if (res !== 1) { throw 'unexpected value for non existing key incr result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"INCR", "existing_key"},
+		{"INCR", "non_existing_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientIncrBy(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("INCRBY", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'INCRBY' command"))
+			return
+		}
+
+		value, err := strconv.Atoi(args[1])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		existingValue := 10
+
+		switch args[0] {
+		case "existing_key":
+			c.WriteInteger(existingValue + value)
+		case "non_existing_key":
+			c.WriteInteger(0 + value)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.incrBy("existing_key", 10)
+				.then(res => { if (res !== 20) { throw 'unexpected value for incrBy result: ' + res } })
+				.then(() => redis.incrBy("non_existing_key", 10))
+				.then(res => { if (res !== 10) { throw 'unexpected value for incrBy result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"INCRBY", "existing_key", "10"},
+		{"INCRBY", "non_existing_key", "10"},
+	}, rs.GotCommands())
+}
+
+func TestClientDecr(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("DECR", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'DECR' command"))
+			return
+		}
+
+		existingValue := 10
+
+		switch args[0] {
+		case "existing_key":
+			c.WriteInteger(existingValue - 1)
+		case "non_existing_key":
+			c.WriteInteger(0 - 1)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.decr("existing_key")
+				.then(res => { if (res !== 9) { throw 'unexpected value for decr result: ' + res } })
+				.then(() => redis.decr("non_existing_key"))
+				.then(res => { if (res !== -1) { throw 'unexpected value for decr result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"DECR", "existing_key"},
+		{"DECR", "non_existing_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientDecrBy(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("DECRBY", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'DECRBY' command"))
+			return
+		}
+
+		value, err := strconv.Atoi(args[1])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		existingValue := 10
+
+		switch args[0] {
+		case "existing_key":
+			c.WriteInteger(existingValue - value)
+		case "non_existing_key":
+			c.WriteInteger(0 - value)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.decrBy("existing_key", 2)
+				.then(res => { if (res !== 8) { throw 'unexpected value for decrBy result: ' + res } })
+				.then(() => redis.decrBy("non_existing_key", 2))
+				.then(res => { if (res !== -2) { throw 'unexpected value for decrBy result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"DECRBY", "existing_key", "2"},
+		{"DECRBY", "non_existing_key", "2"},
+	}, rs.GotCommands())
+}
+
+func TestClientRandomKey(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	calledN := 0
+	rs.RegisterCommandHandler("RANDOMKEY", func(c *Connection, args []string) {
+		if len(args) != 0 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'RANDOMKEY' command"))
+			return
+		}
+
+		if calledN == 0 {
+			// let's consider the DB empty
+			calledN++
+			c.WriteNull()
+			return
+		}
+
+		c.WriteBulkString("random_key")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.randomKey()
+				.then(
+					res => { throw 'unexpectedly resolved promise for randomKey command: ' + res },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error: ' + err } }
+				)
+				.then(() => redis.randomKey())
+				.then(res => { if (res !== "random_key") { throw 'unexpected value for randomKey result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"RANDOMKEY"},
+		{"RANDOMKEY"},
+	}, rs.GotCommands())
+}
+
+func TestClientMget(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("MGET", func(c *Connection, args []string) {
+		if len(args) < 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'MGET' command"))
+			return
+		}
+
+		c.WriteArray("old_value", "")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.mget("existing_key", "non_existing_key")
+				.then(
+					res => {
+						if (res.length !== 2 || res[0] !== "old_value" || res[1] !== null) {
+							throw 'unexpected value for mget result: ' + res
+						}
+					}
+				)
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 1, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"MGET", "existing_key", "non_existing_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientExpire(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("EXPIRE", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'EXPIRE' command"))
+			return
+		}
+
+		switch args[0] {
+		case "expires_key":
+			c.WriteInteger(1)
+		case "non_existing_key":
+			c.WriteInteger(0)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.expire("expires_key", 10)
+				.then(res => { if (res !== true) { throw 'unexpected value for expire result: ' + res } })
+				.then(() => redis.expire("non_existing_key", 1))
+				.then(res => { if (res !== false) { throw 'unexpected value for expire result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"EXPIRE", "expires_key", "10"},
+		{"EXPIRE", "non_existing_key", "1"},
+	}, rs.GotCommands())
+}
+
+func TestClientTTL(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("TTL", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'EXPIRE' command"))
+			return
+		}
+
+		switch args[0] {
+		case "expires_key":
+			c.WriteInteger(10)
+		case "non_existing_key":
+			c.WriteInteger(0)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.ttl("expires_key")
+				.then(res => { if (res !== 10) { throw 'unexpected value for expire result: ' + res } })
+				.then(() => redis.ttl("non_existing_key"))
+				.then(res => { if (res > 0) { throw 'unexpected value for expire result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"TTL", "expires_key"},
+		{"TTL", "non_existing_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientPersist(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("PERSIST", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'PERSIST' command"))
+			return
+		}
+
+		switch args[0] {
+		case "expires_key":
+			c.WriteInteger(1)
+		case "non_existing_key":
+			c.WriteInteger(0)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.persist("expires_key")
+				.then(res => { if (res !== true) { throw 'unexpected value for expire result: ' + res } })
+				.then(() => redis.persist("non_existing_key"))
+				.then(res => { if (res !== false) { throw 'unexpected value for expire result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"PERSIST", "expires_key"},
+		{"PERSIST", "non_existing_key"},
+	}, rs.GotCommands())
+}
+
+func TestClientLPush(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("LPUSH", func(c *Connection, args []string) {
+		if len(args) < 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LPUSH' command"))
+			return
+		}
+
+		existingList := []string{"existing_key"}
+
+		switch args[0] {
+		case "existing_list": //nolint:goconst
+			existingList = append(args[1:], existingList...)
+			c.WriteInteger(len(existingList))
+		case "new_list":
+			c.WriteInteger(1)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.lpush("existing_list", "second", "first")
+				.then(res => { if (res !== 3) { throw 'unexpected value for lpush result: ' + res } })
+				.then(() => redis.lpush("new_list", 1))
+				.then(res => { if (res !== 1) { throw 'unexpected value for lpush result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LPUSH", "existing_list", "second", "first"},
+		{"LPUSH", "new_list", "1"},
+	}, rs.GotCommands())
+}
+
+func TestClientRPush(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("RPUSH", func(c *Connection, args []string) {
+		if len(args) < 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'RPUSH' command"))
+			return
+		}
+
+		existingList := []string{"existing_key"}
+
+		switch args[0] {
+		case "existing_list":
+			existingList = append(existingList, args[1:]...)
+			c.WriteInteger(len(existingList))
+		case "new_list":
+			c.WriteInteger(1)
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.rpush("existing_list", "second", "third")
+				.then(res => { if (res !== 3) { throw 'unexpected value for rpush result: ' + res } })
+				.then(() => redis.rpush("new_list", 1))
+				.then(res => { if (res !== 1) { throw 'unexpected value for rpush result: ' + res } })
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"RPUSH", "existing_list", "second", "third"},
+		{"RPUSH", "new_list", "1"},
+	}, rs.GotCommands())
+}
+
+func TestClientLPop(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	listState := []string{"first", "second"}
+	rs.RegisterCommandHandler("LPOP", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LPOP' command"))
+			return
+		}
+
+		switch args[0] {
+		case "existing_list":
+			c.WriteBulkString(listState[0])
+			listState = listState[1:]
+		case "non_existing_list": //nolint:goconst
+			c.WriteNull()
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.lpop("existing_list")
+				.then(res => { if (res !== "first") { throw 'unexpected value for lpop first result: ' + res } })
+				.then(() => redis.lpop("existing_list"))
+				.then(res => { if (res !== "second") { throw 'unexpected value for lpop second result: ' + res } })
+				.then(() => redis.lpop("non_existing_list"))
+				.then(
+					res => { if (res !== null) { throw 'unexpectedly resolved lpop promise: ' + res } },
+
+					// An error is returned if the list does not exist
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for lpop: ' + err.error() } }
+				)
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LPOP", "existing_list"},
+		{"LPOP", "existing_list"},
+		{"LPOP", "non_existing_list"},
+	}, rs.GotCommands())
+}
+
+func TestClientRPop(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	listState := []string{"first", "second"}
+	rs.RegisterCommandHandler("RPOP", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'RPOP' command"))
+			return
+		}
+
+		switch args[0] {
+		case "existing_list":
+			c.WriteBulkString(listState[len(listState)-1])
+			listState = listState[:len(listState)-1]
+		case "non_existing_list":
+			c.WriteNull()
+		}
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.rpop("existing_list")
+				.then(res => { if (res !== "second") { throw 'unexpected value for rpop result: ' + res }})
+				.then(() => redis.rpop("existing_list"))
+				.then(res => { if (res !== "first") { throw 'unexpected value for rpop result: ' + res }})
+				.then(() => redis.rpop("non_existing_list"))
+				.then(
+					res => { if (res !== null) { throw 'unexpectedly resolved lpop promise: ' + res } },
+
+					// An error is returned if the list does not exist
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for rpop: ' + err.error() } }
+				)
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"RPOP", "existing_list"},
+		{"RPOP", "existing_list"},
+		{"RPOP", "non_existing_list"},
+	}, rs.GotCommands())
+}
+
+func TestClientLRange(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	listState := []string{"first", "second", "third"}
+	rs.RegisterCommandHandler("LRANGE", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LRANGE' command"))
+			return
+		}
+
+		start, err := strconv.Atoi(args[1])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		stop, err := strconv.Atoi(args[2])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		if start < 0 {
+			start = len(listState) + start
+		}
+
+		// This calculation is done in a way that is not 100% correct, but it is
+		// good enough for the test.
+		c.WriteArray(listState[start : stop+1]...)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.lrange("existing_list", 0, 0)
+				.then(res => { if (res.length !== 1 || res[0] !== "first") { throw 'unexpected value for lrange result: ' + res }})
+				.then(() => redis.lrange("existing_list", 0, 1))
+				.then(res => { if (res.length !== 2 || res[0] !== "first" || res[1] !== "second") { throw 'unexpected value for lrange result: ' + res } })
+				.then(() => redis.lrange("existing_list", -2, 2))
+				.then(res => {
+					if (res.length !== 2 ||
+						res[0] !== "second" ||
+						res[1] !== "third") {
+						throw 'unexpected value for lrange result: ' + res
+					}
+				})
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LRANGE", "existing_list", "0", "0"},
+		{"LRANGE", "existing_list", "0", "1"},
+		{"LRANGE", "existing_list", "-2", "2"},
+	}, rs.GotCommands())
+}
+
+func TestClientLIndex(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	listState := []string{"first", "second", "third"}
+	rs.RegisterCommandHandler("LINDEX", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LINDEX' command"))
+			return
+		}
+
+		if args[0] == "non_existing_list" {
+			c.WriteNull()
+			return
+		}
+
+		index, err := strconv.Atoi(args[1])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		if index > len(listState)-1 {
+			c.WriteNull()
+			return
+		}
+
+		// This calculation is done in a way that is not 100% correct, but it is
+		// good enough for the test.
+		c.WriteBulkString(listState[index])
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.lindex("existing_list", 0)
+				.then(res => { if (res !== "first") { throw 'unexpected value for lindex result: ' + res } })
+				.then(() => redis.lindex("existing_list", 3))
+				.then(
+					res => { throw 'unexpectedly resolved lindex command promise: ' + res },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for lindex: ' + err.error() } }
+				)
+				.then(() => redis.lindex("non_existing_list", 0))
+				.then(
+					res => { throw 'unexpectedly resolved lindex command promise: ' + res },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for lindex: ' + err.error() } }
+				)
+		`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LINDEX", "existing_list", "0"},
+		{"LINDEX", "existing_list", "3"},
+		{"LINDEX", "non_existing_list", "0"},
+	}, rs.GotCommands())
+}
+
+func TestClientClientLSet(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	listState := []string{"first"}
+	rs.RegisterCommandHandler("LSET", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LSET' command"))
+			return
+		}
+
+		if args[0] == "non_existing_list" {
+			c.WriteError(errors.New("ERR no such key"))
+			return
+		}
+
+		index, err := strconv.Atoi(args[1])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		listState[index] = args[2]
+		c.WriteOK()
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.lset("existing_list", 0, "new_first")
+				.then(res => { if (res !== "OK") { throw 'unexpected value for lset result: ' + res }})
+				.then(() => redis.lset("existing_list", 0, "overridden_value"))
+				.then(() => redis.lset("non_existing_list", 0, "new_first"))
+				.then(
+					res => { if (res !== null) { throw 'unexpectedly resolved promise: ' + res } },
+					err => { if (err.error() != 'ERR no such key') { throw 'unexpected error for lset: ' + err.error() } }
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LSET", "existing_list", "0", "new_first"},
+		{"LSET", "existing_list", "0", "overridden_value"},
+		{"LSET", "non_existing_list", "0", "new_first"},
+	}, rs.GotCommands())
+}
+
+func TestClientLrem(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("LREM", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LREM' command"))
+			return
+		}
+
+		if args[0] == "non_existing_list" {
+			c.WriteError(errors.New("ERR no such key"))
+			return
+		}
+
+		c.WriteInteger(1)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.lrem("existing_list", 1, "first")
+				.then(() => redis.lrem("existing_list", 0, "second"))
+				.then(() => {
+					redis.lrem("non_existing_list", 2, "third")
+						.then(
+							res => { if (res !== null) { throw 'unexpectedly resolved promise: ' + res } },
+							err => { if (err.error() != 'ERR no such key') { throw 'unexpected error for lrem: ' + err.error() } },
+						)
+				})
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LREM", "existing_list", "1", "first"},
+		{"LREM", "existing_list", "0", "second"},
+		{"LREM", "non_existing_list", "2", "third"},
+	}, rs.GotCommands())
+}
+
+func TestClientLlen(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("LLEN", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LREM' command"))
+			return
+		}
+
+		if args[0] == "non_existing_list" {
+			c.WriteError(errors.New("ERR no such key"))
+			return
+		}
+
+		c.WriteInteger(3)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.llen("existing_list")
+				.then(res => { if (res !== 3) { throw 'unexpected value for llen result: ' + res } })
+				.then(() => {
+					redis.llen("non_existing_list")
+						.then(
+							res => { if (res !== null) { throw 'unexpectedly resolved promise: ' + res } },
+							err => { if (err.error() != 'ERR no such key') { throw 'unexpected error for llen: ' + err.error() } }
+						)
+				})
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"LLEN", "existing_list"},
+		{"LLEN", "non_existing_list"},
+	}, rs.GotCommands())
+}
+
+func TestClientHSet(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HSET", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'LREM' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" { //nolint:goconst
+			c.WriteError(errors.New("ERR no such key"))
+			return
+		}
+
+		c.WriteInteger(1)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hset("existing_hash", "key", "value")
+				.then(res => { if (res !== 1) { throw 'unexpected value for hset result: ' + res } })
+				.then(() => redis.hset("existing_hash", "fou", "barre"))
+				.then(res => { if (res !== 1) { throw 'unexpected value for hset result: ' + res } })
+				.then(() => redis.hset("non_existing_hash", "cle", "valeur"))
+				.then(
+					res => { if (res !== null) { throw 'unexpectedly resolved promise: ' + res } },
+					err => { if (err.error() != 'ERR no such key') { throw 'unexpected error for hset: ' + err.error() } },
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HSET", "existing_hash", "key", "value"},
+		{"HSET", "existing_hash", "fou", "barre"},
+		{"HSET", "non_existing_hash", "cle", "valeur"},
+	}, rs.GotCommands())
+}
+
+func TestClientHsetnx(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HSETNX", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HSETNX' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteInteger(1) // HSET on a non existing hash creates it
+			return
+		}
+
+		// key does not exist
+		if args[1] == "key" {
+			c.WriteInteger(1)
+			return
+		}
+
+		// key already exists
+		c.WriteInteger(0)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hsetnx("existing_hash", "key", "value")
+				.then(res => { if (res !== true) { throw 'unexpected value for hsetnx result: ' + res } })
+				.then(() => redis.hsetnx("existing_hash", "foo", "barre"))
+				.then(res => { if (res !== false) { throw 'unexpected value for hsetnx result: ' + res } })
+				.then(() => redis.hsetnx("non_existing_hash", "key", "value"))
+				.then(res => { if (res !== true) { throw 'unexpected value for hsetnx result: ' + res } })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HSETNX", "existing_hash", "key", "value"},
+		{"HSETNX", "existing_hash", "foo", "barre"},
+		{"HSETNX", "non_existing_hash", "key", "value"},
+	}, rs.GotCommands())
+}
+
+func TestClientHget(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HGET", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HGET' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteNull()
+			return
+		}
+
+		c.WriteBulkString("bar")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hget("existing_hash", "foo")
+				.then(res => { if (res !== "bar") { throw 'unexpected value for hget result: ' + res } })
+				.then(() => redis.hget("non_existing_hash", "key"))
+				.then(
+					res => { throw 'unexpectedly resolved hget promise : ' + res },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for hget: ' + err.error() } },
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HGET", "existing_hash", "foo"},
+		{"HGET", "non_existing_hash", "key"},
+	}, rs.GotCommands())
+}
+
+func TestClientHdel(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HDEL", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HDEL' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" || args[1] == "non_existing_key" {
+			c.WriteInteger(0)
+			return
+		}
+
+		c.WriteInteger(1)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hdel("existing_hash", "foo")
+				.then(res => { if (res !== 1) { throw 'unexpected value for hdel result: ' + res } })
+				.then(() => redis.hdel("existing_hash", "non_existing_key"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for hdel result: ' + res } })
+				.then(() => redis.hdel("non_existing_hash", "key"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for hdel result: ' + res } })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HDEL", "existing_hash", "foo"},
+		{"HDEL", "existing_hash", "non_existing_key"},
+		{"HDEL", "non_existing_hash", "key"},
+	}, rs.GotCommands())
+}
+
+func TestClientHgetall(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HGETALL", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HGETALL' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteArray()
+			return
+		}
+
+		c.WriteArray("foo", "bar")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hgetall("existing_hash")
+				.then(res => { if (typeof res !== "object" || res['foo'] !== 'bar') { throw 'unexpected value for hgetall result: ' + res } })
+				.then(() => redis.hgetall("non_existing_hash"))
+				.then(
+					res => { if (Object.keys(res).length !== 0) { throw 'unexpected value for hgetall result: ' + res} },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for hgetall: ' + err.error() } },
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HGETALL", "existing_hash"},
+		{"HGETALL", "non_existing_hash"},
+	}, rs.GotCommands())
+}
+
+func TestClientHkeys(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HKEYS", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HKEYS' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteArray()
+			return
+		}
+
+		c.WriteArray("foo")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hkeys("existing_hash")
+				.then(res => { if (res.length !== 1 || res[0] !== 'foo') { throw 'unexpected value for hkeys result: ' + res } })
+				.then(() => redis.hkeys("non_existing_hash"))
+				.then(
+					res => { if (res.length !== 0) { throw 'unexpected value for hkeys result: ' + res} },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for hkeys: ' + err.error() } },
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HKEYS", "existing_hash"},
+		{"HKEYS", "non_existing_hash"},
+	}, rs.GotCommands())
+}
+
+func TestClientHvals(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HVALS", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HVALS' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteArray()
+			return
+		}
+
+		c.WriteArray("bar")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hvals("existing_hash")
+				.then(res => { if (res.length !== 1 || res[0] !== 'bar') { throw 'unexpected value for hvals result: ' + res } })
+				.then(() => redis.hvals("non_existing_hash"))
+				.then(
+					res => { if (res.length !== 0) { throw 'unexpected value for hvals result: ' + res} },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for hvals: ' + err.error() } },
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HVALS", "existing_hash"},
+		{"HVALS", "non_existing_hash"},
+	}, rs.GotCommands())
+}
+
+func TestClientHlen(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("HLEN", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HLEN' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteInteger(0)
+			return
+		}
+
+		c.WriteInteger(1)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hlen("existing_hash")
+				.then(res => { if (res !== 1) { throw 'unexpected value for hlen result: ' + res } })
+				.then(() => redis.hlen("non_existing_hash"))
+				.then(
+					res => { if (res !== 0) { throw 'unexpected value for hlen result: ' + res} },
+					err => { if (err.error() != 'redis: nil') { throw 'unexpected error for hlen: ' + err.error() } },
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HLEN", "existing_hash"},
+		{"HLEN", "non_existing_hash"},
+	}, rs.GotCommands())
+}
+
+func TestClientHincrby(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	fooHValue := 1
+	rs.RegisterCommandHandler("HINCRBY", func(c *Connection, args []string) {
+		if len(args) != 3 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'HINCRBY' command"))
+			return
+		}
+
+		if args[0] == "non_existing_hash" {
+			c.WriteInteger(1)
+			return
+		}
+
+		value, err := strconv.Atoi(args[2])
+		if err != nil {
+			c.WriteError(err)
+			return
+		}
+
+		fooHValue += value
+
+		c.WriteInteger(fooHValue)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.hincrby("existing_hash", "foo", 1)
+				.then(res => { if (res !== 2) { throw 'unexpected value for hincrby result: ' + res } })
+				.then(() => redis.hincrby("existing_hash", "foo", -1))
+				.then(res => { if (res !== 1) { throw 'unexpected value for hincrby result: ' + res } })
+				.then(() => redis.hincrby("non_existing_hash", "foo", 1))
+				.then(res => { if (res !== 1) { throw 'unexpected value for hincrby result: ' + res } })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"HINCRBY", "existing_hash", "foo", "1"},
+		{"HINCRBY", "existing_hash", "foo", "-1"},
+		{"HINCRBY", "non_existing_hash", "foo", "1"},
+	}, rs.GotCommands())
+}
+
+func TestClientSadd(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	barWasSet := false
+	rs.RegisterCommandHandler("SADD", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SADD' command"))
+			return
+		}
+
+		if args[0] == "non_existing_set" { //nolint:goconst
+			c.WriteInteger(1)
+			return
+		}
+
+		if barWasSet == false {
+			barWasSet = true
+			c.WriteInteger(1)
+			return
+		}
+
+		c.WriteInteger(0)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.sadd("existing_set", "bar")
+				.then(res => { if (res !== 1) { throw 'unexpected value for sadd result: ' + res } })
+				.then(() => redis.sadd("existing_set", "bar"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for sadd result: ' + res } })
+				.then(() => redis.sadd("non_existing_set", "foo"))
+				.then(res => { if (res !== 1) { throw 'unexpected value for sadd result: ' + res} })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SADD", "existing_set", "bar"},
+		{"SADD", "existing_set", "bar"},
+		{"SADD", "non_existing_set", "foo"},
+	}, rs.GotCommands())
+}
+
+func TestClientSrem(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	fooWasRemoved := false
+	rs.RegisterCommandHandler("SREM", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SREM' command"))
+			return
+		}
+
+		if args[0] == "non_existing_set" {
+			c.WriteInteger(0)
+			return
+		}
+
+		if fooWasRemoved == false {
+			fooWasRemoved = true
+			c.WriteInteger(1)
+			return
+		}
+
+		c.WriteInteger(0)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.srem("existing_set", "foo")
+				.then(res => { if (res !== 1) { throw 'unexpected value for srem result: ' + res } })
+				.then(() => redis.srem("existing_set", "foo"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for srem result: ' + res } })
+				.then(() => redis.srem("existing_set", "doesnotexist"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for srem result: ' + res } })
+				.then(() => redis.srem("non_existing_set", "foo"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for srem result: ' + res} })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 4, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SREM", "existing_set", "foo"},
+		{"SREM", "existing_set", "foo"},
+		{"SREM", "existing_set", "doesnotexist"},
+		{"SREM", "non_existing_set", "foo"},
+	}, rs.GotCommands())
+}
+
+func TestClientSismember(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("SISMEMBER", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SISMEMBER' command"))
+			return
+		}
+
+		if args[0] == "non_existing_set" {
+			c.WriteInteger(0)
+			return
+		}
+
+		if args[1] == "foo" {
+			c.WriteInteger(1)
+			return
+		}
+
+		c.WriteInteger(0)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.sismember("existing_set", "foo")
+				.then(res => { if (res !== true) { throw 'unexpected value for sismember result: ' + res } })
+				.then(() => redis.sismember("existing_set", "bar"))
+				.then(res => { if (res !== false) { throw 'unexpected value for sismember result: ' + res } })
+				.then(() => redis.sismember("non_existing_set", "foo"))
+				.then(res => { if (res !== false) { throw 'unexpected value for sismember result: ' + res} })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 3, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SISMEMBER", "existing_set", "foo"},
+		{"SISMEMBER", "existing_set", "bar"},
+		{"SISMEMBER", "non_existing_set", "foo"},
+	}, rs.GotCommands())
+}
+
+func TestClientSmembers(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("SMEMBERS", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SMEMBERS' command"))
+			return
+		}
+
+		if args[0] == "non_existing_set" {
+			c.WriteArray()
+			return
+		}
+
+		c.WriteArray("foo", "bar")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.smembers("existing_set")
+				.then(res => { if (res.length !== 2 || 'foo' in res || 'bar' in res) { throw 'unexpected value for smembers result: ' + res } })
+				.then(() => redis.smembers("non_existing_set"))
+				.then(res => { if (res.length !== 0) { throw 'unexpected value for smembers result: ' + res} })
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SMEMBERS", "existing_set"},
+		{"SMEMBERS", "non_existing_set"},
+	}, rs.GotCommands())
+}
+
+func TestClientSrandmember(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("SRANDMEMBER", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SRANDMEMBER' command"))
+			return
+		}
+
+		if args[0] == "non_existing_set" {
+			c.WriteError(errors.New("ERR no elements in set"))
+			return
+		}
+
+		c.WriteBulkString("foo")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.srandmember("existing_set")
+				.then(res => { if (res !== 'foo' && res !== 'bar') { throw 'unexpected value for srandmember result: ' + res} })
+				.then(() => redis.srandmember("non_existing_set"))
+				.then(
+					res => { throw 'unexpectedly resolved promise for srandmember result: ' + res },
+					err => { if (err.error() !== 'ERR no elements in set') { throw 'unexpected error for srandmember operation: ' + err.error() } }
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SRANDMEMBER", "existing_set"},
+		{"SRANDMEMBER", "non_existing_set"},
+	}, rs.GotCommands())
+}
+
+func TestClientSpop(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	rs.RegisterCommandHandler("SPOP", func(c *Connection, args []string) {
+		if len(args) != 1 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SPOP' command"))
+			return
+		}
+
+		if args[0] == "non_existing_set" {
+			c.WriteError(errors.New("ERR no elements in set"))
+			return
+		}
+
+		c.WriteBulkString("foo")
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.spop("existing_set")
+				.then(res => { if (res !== 'foo' && res !== 'bar') { throw 'unexpected value for spop result: ' + res} })
+				.then(() => redis.spop("non_existing_set"))
+				.then(
+					res => { throw 'unexpectedly resolved promise for spop result: ' + res },
+					err => { if (err.error() !== 'ERR no elements in set') { throw 'unexpected error for srandmember operation: ' + err.error() } }
+				)
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SPOP", "existing_set"},
+		{"SPOP", "non_existing_set"},
+	}, rs.GotCommands())
+}
+
+func TestClientSendCommand(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	rs := RunT(t)
+	fooWasSet := false
+	rs.RegisterCommandHandler("SADD", func(c *Connection, args []string) {
+		if len(args) != 2 {
+			c.WriteError(errors.New("ERR unexpected number of arguments for 'SADD' command"))
+			return
+		}
+
+		if args[1] == "foo" && !fooWasSet {
+			fooWasSet = true
+			c.WriteInteger(1)
+			return
+		}
+
+		c.WriteInteger(0)
+	})
+
+	gotScriptErr := ts.ev.Start(func() error {
+		_, err := ts.rt.RunString(fmt.Sprintf(`
+			const redis = new Client({
+				addrs: new Array("%s"),
+			});
+
+			redis.sendCommand("sadd", "existing_set", "foo")
+				.then(res => { if (res !== 1) { throw 'unexpected value for sadd result: ' + res } })
+				.then(() => redis.sendCommand("sadd", "existing_set", "foo"))
+				.then(res => { if (res !== 0) { throw 'unexpected value for sadd result: ' + res } })
+
+			`, rs.Addr()))
+
+		return err
+	})
+
+	assert.NoError(t, gotScriptErr)
+	assert.Equal(t, 2, rs.HandledCommandsCount())
+	assert.Equal(t, [][]string{
+		{"SADD", "existing_set", "foo"},
+		{"SADD", "existing_set", "foo"},
+	}, rs.GotCommands())
+}
+
+func TestClientCommandsInInitContext(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "set should fail when used in the init context",
+			statement: "redis.set('should', 'fail')",
+		},
+		{
+			name:      "get should fail when used in the init context",
+			statement: "redis.get('shouldfail')",
+		},
+		{
+			name:      "getSet should fail when used in the init context",
+			statement: "redis.getSet('should', 'fail')",
+		},
+		{
+			name:      "del should fail when used in the init context",
+			statement: "redis.del('should', 'fail')",
+		},
+		{
+			name:      "getDel should fail when used in the init context",
+			statement: "redis.getDel('shouldfail')",
+		},
+		{
+			name:      "exists should fail when used in the init context",
+			statement: "redis.exists('should', 'fail')",
+		},
+		{
+			name:      "incr should fail when used in the init context",
+			statement: "redis.incr('shouldfail')",
+		},
+		{
+			name:      "incrBy should fail when used in the init context",
+			statement: "redis.incrBy('shouldfail', 10)",
+		},
+		{
+			name:      "decr should fail when used in the init context",
+			statement: "redis.decr('shouldfail')",
+		},
+		{
+			name:      "decrBy should fail when used in the init context",
+			statement: "redis.decrBy('shouldfail', 10)",
+		},
+		{
+			name:      "randomKey should fail when used in the init context",
+			statement: "redis.randomKey()",
+		},
+		{
+			name:      "mget should fail when used in the init context",
+			statement: "redis.mget('should', 'fail')",
+		},
+		{
+			name:      "expire should fail when used in the init context",
+			statement: "redis.expire('shouldfail', 10)",
+		},
+		{
+			name:      "ttl should fail when used in the init context",
+			statement: "redis.ttl('shouldfail')",
+		},
+		{
+			name:      "persist should fail when used in the init context",
+			statement: "redis.persist('shouldfail')",
+		},
+		{
+			name:      "lpush should fail when used in the init context",
+			statement: "redis.lpush('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "rpush should fail when used in the init context",
+			statement: "redis.rpush('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "lpop should fail when used in the init context",
+			statement: "redis.lpop('shouldfail')",
+		},
+		{
+			name:      "rpop should fail when used in the init context",
+			statement: "redis.rpop('shouldfail')",
+		},
+		{
+			name:      "lrange should fail when used in the init context",
+			statement: "redis.lrange('shouldfail', 0, 5)",
+		},
+		{
+			name:      "lindex should fail when used in the init context",
+			statement: "redis.lindex('shouldfail', 1)",
+		},
+		{
+			name:      "lset should fail when used in the init context",
+			statement: "redis.lset('shouldfail', 1, 'fail')",
+		},
+		{
+			name:      "lrem should fail when used in the init context",
+			statement: "redis.lrem('should', 1, 'fail')",
+		},
+		{
+			name:      "llen should fail when used in the init context",
+			statement: "redis.llen('shouldfail')",
+		},
+		{
+			name:      "hset should fail when used in the init context",
+			statement: "redis.hset('shouldfail', 'foo', 'bar')",
+		},
+		{
+			name:      "hsetnx should fail when used in the init context",
+			statement: "redis.hsetnx('shouldfail', 'foo', 'bar')",
+		},
+		{
+			name:      "hget should fail when used in the init context",
+			statement: "redis.hget('should', 'fail')",
+		},
+		{
+			name:      "hdel should fail when used in the init context",
+			statement: "redis.hdel('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "hgetall should fail when used in the init context",
+			statement: "redis.hgetall('shouldfail')",
+		},
+		{
+			name:      "hkeys should fail when used in the init context",
+			statement: "redis.hkeys('shouldfail')",
+		},
+		{
+			name:      "hvals should fail when used in the init context",
+			statement: "redis.hvals('shouldfail')",
+		},
+		{
+			name:      "hlen should fail when used in the init context",
+			statement: "redis.hlen('shouldfail')",
+		},
+		{
+			name:      "hincrby should fail when used in the init context",
+			statement: "redis.hincrby('should', 'fail', 10)",
+		},
+		{
+			name:      "sadd should fail when used in the init context",
+			statement: "redis.sadd('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "srem should fail when used in the init context",
+			statement: "redis.srem('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "sismember should fail when used in the init context",
+			statement: "redis.sismember('should', 'fail')",
+		},
+		{
+			name:      "smembers should fail when used in the init context",
+			statement: "redis.smembers('shouldfail')",
+		},
+		{
+			name:      "srandmember should fail when used in the init context",
+			statement: "redis.srandmember('shouldfail')",
+		},
+		{
+			name:      "persist should fail when used in the init context",
+			statement: "redis.persist('shouldfail')",
+		},
+		{
+			name:      "spop should fail when used in the init context",
+			statement: "redis.spop('shouldfail')",
+		},
+		{
+			name:      "sendCommand should fail when used in the init context",
+			statement: "redis.sendCommand('GET', 'shouldfail')",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := newInitContextTestSetup(t)
+
+			gotScriptErr := ts.ev.Start(func() error {
+				_, err := ts.rt.RunString(fmt.Sprintf(`
+				const redis = new Client({
+					addrs: new Array("unreachable:42424"),
+				});
+	
+				%s.then(res => { throw 'expected to fail when called in the init context' })
+			`, tc.statement))
+
+				return err
+			})
+
+			assert.Error(t, gotScriptErr)
+		})
+	}
+}
+
+func TestClientCommandsAgainstUnreachableServer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "set should fail when server is unreachable",
+			statement: "redis.set('should', 'fail')",
+		},
+		{
+			name:      "get should fail when server is unreachable",
+			statement: "redis.get('shouldfail')",
+		},
+		{
+			name:      "getSet should fail when server is unreachable",
+			statement: "redis.getSet('should', 'fail')",
+		},
+		{
+			name:      "del should fail when server is unreachable",
+			statement: "redis.del('should', 'fail')",
+		},
+		{
+			name:      "getDel should fail when server is unreachable",
+			statement: "redis.getDel('shouldfail')",
+		},
+		{
+			name:      "exists should fail when server is unreachable",
+			statement: "redis.exists('should', 'fail')",
+		},
+		{
+			name:      "incr should fail when server is unreachable",
+			statement: "redis.incr('shouldfail')",
+		},
+		{
+			name:      "incrBy should fail when server is unreachable",
+			statement: "redis.incrBy('shouldfail', 10)",
+		},
+		{
+			name:      "decr should fail when server is unreachable",
+			statement: "redis.decr('shouldfail')",
+		},
+		{
+			name:      "decrBy should fail when server is unreachable",
+			statement: "redis.decrBy('shouldfail', 10)",
+		},
+		{
+			name:      "randomKey should fail when server is unreachable",
+			statement: "redis.randomKey()",
+		},
+		{
+			name:      "mget should fail when server is unreachable",
+			statement: "redis.mget('should', 'fail')",
+		},
+		{
+			name:      "expire should fail when server is unreachable",
+			statement: "redis.expire('shouldfail', 10)",
+		},
+		{
+			name:      "ttl should fail when server is unreachable",
+			statement: "redis.ttl('shouldfail')",
+		},
+		{
+			name:      "persist should fail when server is unreachable",
+			statement: "redis.persist('shouldfail')",
+		},
+		{
+			name:      "lpush should fail when server is unreachable",
+			statement: "redis.lpush('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "rpush should fail when server is unreachable",
+			statement: "redis.rpush('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "lpop should fail when server is unreachable",
+			statement: "redis.lpop('shouldfail')",
+		},
+		{
+			name:      "rpop should fail when server is unreachable",
+			statement: "redis.rpop('shouldfail')",
+		},
+		{
+			name:      "lrange should fail when server is unreachable",
+			statement: "redis.lrange('shouldfail', 0, 5)",
+		},
+		{
+			name:      "lindex should fail when server is unreachable",
+			statement: "redis.lindex('shouldfail', 1)",
+		},
+		{
+			name:      "lset should fail when server is unreachable",
+			statement: "redis.lset('shouldfail', 1, 'fail')",
+		},
+		{
+			name:      "lrem should fail when server is unreachable",
+			statement: "redis.lrem('should', 1, 'fail')",
+		},
+		{
+			name:      "llen should fail when server is unreachable",
+			statement: "redis.llen('shouldfail')",
+		},
+		{
+			name:      "hset should fail when server is unreachable",
+			statement: "redis.hset('shouldfail', 'foo', 'bar')",
+		},
+		{
+			name:      "hsetnx should fail when server is unreachable",
+			statement: "redis.hsetnx('shouldfail', 'foo', 'bar')",
+		},
+		{
+			name:      "hget should fail when server is unreachable",
+			statement: "redis.hget('should', 'fail')",
+		},
+		{
+			name:      "hdel should fail when server is unreachable",
+			statement: "redis.hdel('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "hgetall should fail when server is unreachable",
+			statement: "redis.hgetall('shouldfail')",
+		},
+		{
+			name:      "hkeys should fail when server is unreachable",
+			statement: "redis.hkeys('shouldfail')",
+		},
+		{
+			name:      "hvals should fail when server is unreachable",
+			statement: "redis.hvals('shouldfail')",
+		},
+		{
+			name:      "hlen should fail when server is unreachable",
+			statement: "redis.hlen('shouldfail')",
+		},
+		{
+			name:      "hincrby should fail when server is unreachable",
+			statement: "redis.hincrby('should', 'fail', 10)",
+		},
+		{
+			name:      "sadd should fail when server is unreachable",
+			statement: "redis.sadd('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "srem should fail when server is unreachable",
+			statement: "redis.srem('should', 'fail', 'indeed')",
+		},
+		{
+			name:      "sismember should fail when server is unreachable",
+			statement: "redis.sismember('should', 'fail')",
+		},
+		{
+			name:      "smembers should fail when server is unreachable",
+			statement: "redis.smembers('shouldfail')",
+		},
+		{
+			name:      "srandmember should fail when server is unreachable",
+			statement: "redis.srandmember('shouldfail')",
+		},
+		{
+			name:      "persist should fail when server is unreachable",
+			statement: "redis.persist('shouldfail')",
+		},
+		{
+			name:      "spop should fail when server is unreachable",
+			statement: "redis.spop('shouldfail')",
+		},
+		{
+			name:      "sendCommand should fail when server is unreachable",
+			statement: "redis.sendCommand('GET', 'shouldfail')",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := newTestSetup(t)
+
+			gotScriptErr := ts.ev.Start(func() error {
+				_, err := ts.rt.RunString(fmt.Sprintf(`
+				const redis = new Client({
+					addrs: new Array("unreachable:42424"),
+				});
+	
+				%s.then(res => { throw 'expected to fail when server is unreachable' })
+			`, tc.statement))
+
+				return err
+			})
+
+			assert.Error(t, gotScriptErr)
+		})
+	}
 }
 
 func TestClientIsSupportedType(t *testing.T) {
@@ -246,19 +2399,24 @@ func TestClientIsSupportedType(t *testing.T) {
 		gotErr := c.isSupportedType(3, int(123), []string{"1", "2", "3"})
 
 		assert.Error(t, gotErr)
-		assert.Contains(t, gotErr.Error(), "argument at index: 4")
+		assert.Contains(t, gotErr.Error(), "argument at index 4")
 	})
 }
 
+// testSetup is a helper struct holding components
+// necessary to test the redis client, in the context
+// of the execution of a k6 script.
 type testSetup struct {
-	tb      *httpmultibin.HTTPMultiBin
 	rt      *goja.Runtime
 	state   *lib.State
 	samples chan metrics.SampleContainer
 	ev      *eventloop.EventLoop
-	redis   *miniredis.Miniredis
 }
 
+// newTestSetup initializes a new test setup.
+// It prepares a test setup with a mocked redis server and a goja runtime,
+// and event loop, ready to execute scripts as if being executed in the
+// main context of k6.
 func newTestSetup(t testing.TB) testSetup {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
@@ -306,17 +2464,20 @@ func newTestSetup(t testing.TB) testSetup {
 		state:   state,
 		samples: samples,
 		ev:      ev,
-		redis:   miniredis.RunT(t),
 	}
 }
 
+// newInitContextTestSetup initializes a new test setup.
+// It prepares a test setup with a mocked redis server and a goja runtime,
+// and event loop, ready to execute scripts as if being executed in the
+// main context of k6.
 func newInitContextTestSetup(t testing.TB) testSetup {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
 	samples := make(chan metrics.SampleContainer, 1000)
 
-	var state *lib.State = nil
+	var state *lib.State
 
 	vu := &modulestest.VU{
 		CtxField:     context.Background(),
@@ -336,6 +2497,5 @@ func newInitContextTestSetup(t testing.TB) testSetup {
 		state:   state,
 		samples: samples,
 		ev:      ev,
-		redis:   miniredis.RunT(t),
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,204 @@
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/eventloop"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/testutils/httpmultibin"
+	"go.k6.io/k6/metrics"
+	"gopkg.in/guregu/null.v3"
+)
+
+func TestClientIsSupportedType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("table tests", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			offset  int
+			args    []interface{}
+			wantErr bool
+		}{
+			{
+				name:    "string is a supported type",
+				offset:  1,
+				args:    []interface{}{"foo"},
+				wantErr: false,
+			},
+			{
+				name:    "int is a supported type",
+				offset:  1,
+				args:    []interface{}{int(123)},
+				wantErr: false,
+			},
+			{
+				name:    "int64 is a supported type",
+				offset:  1,
+				args:    []interface{}{int64(123)},
+				wantErr: false,
+			},
+			{
+				name:    "float64 is a supported type",
+				offset:  1,
+				args:    []interface{}{float64(123)},
+				wantErr: false,
+			},
+			{
+				name:    "bool is a supported type",
+				offset:  1,
+				args:    []interface{}{bool(true)},
+				wantErr: false,
+			},
+			{
+				name:    "multiple identical types args are supported",
+				offset:  1,
+				args:    []interface{}{int(123), int(456)},
+				wantErr: false,
+			},
+			{
+				name:    "multiple mixed types args are supported",
+				offset:  1,
+				args:    []interface{}{int(123), "foo", bool(true)},
+				wantErr: false,
+			},
+			{
+				name:    "slice[T] is not a supported type",
+				offset:  1,
+				args:    []interface{}{[]string{"1", "2", "3"}},
+				wantErr: true,
+			},
+			{
+				name:    "multiple mixed valid and invalid types args are not supported",
+				offset:  1,
+				args:    []interface{}{int(123), []string{"1", "2", "3"}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			tt := tt
+
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				c := &Client{}
+				gotErr := c.isSupportedType(tt.offset, tt.args...)
+				assert.Equal(t,
+					tt.wantErr,
+					gotErr != nil,
+					"Client.isSupportedType() error = %v, wantErr %v", gotErr, tt.wantErr,
+				)
+			})
+		}
+	})
+
+	t.Run("offset is respected in the error message", func(t *testing.T) {
+		t.Parallel()
+
+		c := &Client{}
+
+		gotErr := c.isSupportedType(3, int(123), []string{"1", "2", "3"})
+
+		assert.Error(t, gotErr)
+		assert.Contains(t, gotErr.Error(), "argument at index: 4")
+	})
+}
+
+type testSetup struct {
+	tb      *httpmultibin.HTTPMultiBin
+	rt      *goja.Runtime
+	state   *lib.State
+	samples chan metrics.SampleContainer
+	ev      *eventloop.EventLoop
+	redis   *miniredis.Miniredis
+}
+
+func newTestSetup(t testing.TB) testSetup {
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
+
+	root, err := lib.NewGroup("", nil)
+	require.NoError(t, err)
+
+	samples := make(chan metrics.SampleContainer, 1000)
+
+	state := &lib.State{
+		Group:  root,
+		Dialer: tb.Dialer,
+		Options: lib.Options{
+			SystemTags: metrics.NewSystemTagSet(
+				metrics.TagURL,
+				metrics.TagProto,
+				metrics.TagStatus,
+				metrics.TagSubproto,
+			),
+			UserAgent: null.StringFrom("TestUserAgent"),
+		},
+		Samples:        samples,
+		TLSConfig:      tb.TLSClientConfig,
+		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
+	}
+
+	vu := &modulestest.VU{
+		CtxField:     tb.Context,
+		InitEnvField: &common.InitEnvironment{},
+		RuntimeField: rt,
+		StateField:   state,
+	}
+
+	m := new(RootModule).NewModuleInstance(vu)
+	require.NoError(t, rt.Set("Client", m.Exports().Named["Client"]))
+
+	ev := eventloop.New(vu)
+	vu.RegisterCallbackField = ev.RegisterCallback
+
+	return testSetup{
+		rt:      rt,
+		state:   state,
+		samples: samples,
+		ev:      ev,
+		redis:   miniredis.RunT(t),
+	}
+}
+
+func newInitContextTestSetup(t testing.TB) testSetup {
+	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
+
+	samples := make(chan metrics.SampleContainer, 1000)
+
+	var state *lib.State = nil
+
+	vu := &modulestest.VU{
+		CtxField:     context.Background(),
+		InitEnvField: &common.InitEnvironment{},
+		RuntimeField: rt,
+		StateField:   state,
+	}
+
+	m := new(RootModule).NewModuleInstance(vu)
+	require.NoError(t, rt.Set("Client", m.Exports().Named["Client"]))
+
+	ev := eventloop.New(vu)
+	vu.RegisterCallbackField = ev.RegisterCallback
+
+	return testSetup{
+		rt:      rt,
+		state:   state,
+		samples: samples,
+		ev:      ev,
+		redis:   miniredis.RunT(t),
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/grafana/xk6-redis
 go 1.17
 
 require (
-	github.com/alicebob/miniredis/v2 v2.22.0
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/stretchr/testify v1.7.1
@@ -12,7 +11,6 @@ require (
 )
 
 require (
-	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -32,7 +30,6 @@ require (
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
-	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,26 +3,43 @@ module github.com/grafana/xk6-redis
 go 1.17
 
 require (
+	github.com/alicebob/miniredis/v2 v2.22.0
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/stretchr/testify v1.7.1
 	go.k6.io/k6 v0.38.2
+	gopkg.in/guregu/null.v3 v3.3.0
 )
 
 require (
+	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mccutchen/go-httpbin v1.1.2-0.20190116014521-c5cb2f4802fa // indirect
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
+	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
+	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
-	gopkg.in/guregu/null.v3 v3.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20200903010400-9bfcb5116336 // indirect
+	google.golang.org/grpc v1.45.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5/go.mod h1:5Q4+CyR7+Q3VMG8f78ou+QSX/BNUNUx5W48eFRat8DQ=
+github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
+github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/miniredis/v2 v2.22.0 h1:lIHHiSkEyS1MkKHCHzN+0mWrA4YdbGdimE5iZ2sHSzo=
+github.com/alicebob/miniredis/v2 v2.22.0/go.mod h1:XNqvJdQJv5mSuVMc0ynneafpnL/zv52acZ6kqeS0t88=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
@@ -75,6 +79,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -94,9 +99,11 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
@@ -152,6 +159,8 @@ github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vl
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 h1:k/gmLsJDWwWqbLCur2yWnJzwQEKRcAHXo6seXGuSwWw=
+github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.k6.io/k6 v0.38.2 h1:v4Dr7KhZVf+s6V6oz/pGtQ9ejTfNgUPcd/D3RH3GVdY=
 go.k6.io/k6 v0.38.2/go.mod h1:1bTdDsXTT2V3in3ZgdR15MDW6SQQh5nWni59tirqNB8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -192,6 +201,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -232,6 +242,7 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -265,6 +276,7 @@ google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/l
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/guregu/null.v3 v3.3.0 h1:8j3ggqq+NgKt/O7mbFVUFKUMWN+l1AmT5jQmJ6nPh2c=

--- a/go.sum
+++ b/go.sum
@@ -5,10 +5,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5/go.mod h1:5Q4+CyR7+Q3VMG8f78ou+QSX/BNUNUx5W48eFRat8DQ=
-github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
-github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
-github.com/alicebob/miniredis/v2 v2.22.0 h1:lIHHiSkEyS1MkKHCHzN+0mWrA4YdbGdimE5iZ2sHSzo=
-github.com/alicebob/miniredis/v2 v2.22.0/go.mod h1:XNqvJdQJv5mSuVMc0ynneafpnL/zv52acZ6kqeS0t88=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
@@ -159,8 +155,6 @@ github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vl
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 h1:k/gmLsJDWwWqbLCur2yWnJzwQEKRcAHXo6seXGuSwWw=
-github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.k6.io/k6 v0.38.2 h1:v4Dr7KhZVf+s6V6oz/pGtQ9ejTfNgUPcd/D3RH3GVdY=
 go.k6.io/k6 v0.38.2/go.mod h1:1bTdDsXTT2V3in3ZgdR15MDW6SQQh5nWni59tirqNB8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -201,7 +195,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/stub_test.go
+++ b/stub_test.go
@@ -1,0 +1,526 @@
+package redis
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"unicode"
+)
+
+// RunT starts a new redis stub for a given test context.
+// It registers the test cleanup after your test is done.
+func RunT(t testing.TB) *StubServer {
+	s := NewStubServer()
+	if err := s.Start(); err != nil {
+		t.Fatalf("could not start RedisStub; reason: %s", err)
+	}
+
+	t.Cleanup(s.Close)
+
+	return s
+}
+
+// StubServer is a stub server emulating a Redis server.
+//
+// It implements a minimal redis server capable of handling
+// redis request and response message in the standard RESP
+// protocol format.
+//
+// It is intended to be used in tests. It listens on a random
+// localhost port, and can be used to test client-server interactions.
+// It parses incoming requests, and calls the user-defined handlers
+// to simulate the server's behavior.
+//
+// It is not intended to be used in production.
+type StubServer struct {
+	sync.Mutex
+	waitGroup sync.WaitGroup
+
+	listener  net.Listener
+	boundAddr *net.TCPAddr
+
+	connections     map[net.Conn]struct{}
+	connectionCount int
+
+	handlers          map[string]func(*Connection, []string)
+	processedCommands int
+	commandsHistory   [][]string
+}
+
+// NewStubServer instantiates a new RedisStub server.
+func NewStubServer() *StubServer {
+	return &StubServer{
+		listener:    nil,
+		boundAddr:   nil,
+		connections: map[net.Conn]struct{}{},
+		handlers:    make(map[string]func(*Connection, []string)),
+	}
+}
+
+// Start starts the RedisStub server.
+func (rs *StubServer) Start() error {
+	listener, err := net.Listen("tcp", net.JoinHostPort("localhost", "0"))
+	if err != nil {
+		return err
+	}
+
+	rs.listener = listener
+
+	// the provided addr string binds to port zero,
+	// which leads to automatic port selection by the OS.
+	// To catter for this, we parse the listener address
+	// to get the actual port, the OS bound us to.
+	boundAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return errors.New("could not get TCP address")
+	}
+
+	rs.boundAddr = boundAddr
+
+	rs.waitGroup.Add(1)
+	go func() {
+		defer rs.waitGroup.Done()
+		rs.listenAndServe(listener)
+
+		rs.Lock()
+		for c := range rs.connections {
+			c.Close() //nolint:errcheck,gosec
+		}
+		rs.Unlock()
+	}()
+
+	// The redis-cli will always start a session by sending the
+	// COMMAND message.
+	rs.RegisterCommandHandler("COMMAND", func(c *Connection, args []string) {
+		c.WriteArray("OK")
+	})
+
+	// We register a default PING command handler
+	rs.RegisterCommandHandler("PING", func(c *Connection, args []string) {
+		if len(args) == 1 {
+			c.WriteBulkString(args[0])
+		} else {
+			c.WriteSimpleString("PONG")
+		}
+	})
+
+	return nil
+}
+
+// Close stops the RedisStub server.
+func (rs *StubServer) Close() {
+	rs.Lock()
+	if rs.listener != nil {
+		err := rs.listener.Close()
+		if err != nil {
+			// this is unrecoverable, so we panic.
+			panic(err)
+		}
+	}
+	rs.listener = nil
+	rs.Unlock()
+
+	rs.waitGroup.Wait()
+}
+
+// RegisterCommandHandler registers a handler for a redis command.
+//
+// The handler is called when the command is received. It gives access
+// to a `*Connection` object, which can be used to send responses, using
+// its `Write*` methods.
+func (rs *StubServer) RegisterCommandHandler(command string, handler func(*Connection, []string)) {
+	rs.Lock()
+	defer rs.Unlock()
+	rs.handlers[strings.ToUpper(command)] = handler
+}
+
+// Addr returns the address of the RedisStub server.
+func (rs *StubServer) Addr() string {
+	return rs.boundAddr.String()
+}
+
+// HandledCommandsCount returns the total number of commands
+// ran since the redis stub server started.
+func (rs *StubServer) HandledCommandsCount() int {
+	rs.Lock()
+	defer rs.Unlock()
+	return rs.processedCommands
+}
+
+// HandledConnectionsCount returns the number of established client
+// connections since the redis stub server started.
+func (rs *StubServer) HandledConnectionsCount() int {
+	rs.Lock()
+	defer rs.Unlock()
+	return rs.connectionCount
+}
+
+// GotCommands returns the commands handled (ordered by arrival) by the redis server
+// since it started.
+func (rs *StubServer) GotCommands() [][]string {
+	rs.Lock()
+	defer rs.Unlock()
+	return rs.commandsHistory
+}
+
+// listenAndServe listens on the redis server's listener,
+// and handles client connections.
+func (rs *StubServer) listenAndServe(l net.Listener) {
+	for {
+		nc, err := l.Accept()
+		if err != nil {
+			return
+		}
+
+		rs.waitGroup.Add(1)
+		rs.Lock()
+		rs.connections[nc] = struct{}{}
+		rs.connectionCount++
+		rs.Unlock()
+
+		go func() {
+			defer rs.waitGroup.Done()
+			defer nc.Close() //nolint:errcheck
+
+			rs.handleConnection(nc)
+
+			rs.Lock()
+			delete(rs.connections, nc)
+			rs.Unlock()
+		}()
+	}
+}
+
+// handleConnection handles a single redis client connection.
+func (rs *StubServer) handleConnection(nc net.Conn) {
+	connection := NewConnection(bufio.NewReader(nc), bufio.NewWriter(nc))
+
+	for {
+		command, args, err := connection.ParseRequest()
+		if err != nil {
+			connection.WriteError(ErrInvalidSyntax)
+			return
+		}
+
+		rs.Lock()
+		request := append([]string{command}, args...)
+		rs.commandsHistory = append(rs.commandsHistory, request)
+		rs.Unlock()
+
+		rs.handleCommand(connection, command, args)
+		connection.Flush()
+	}
+}
+
+// ErrUnknownCommand is the error message returned when the server
+// is unable to handle the provided command (because it is not registered).
+var ErrUnknownCommand = errors.New("unknown command")
+
+// HandleCommand handles the provided command and arguments.
+//
+// If the command is not known, it writes the ErrUnknownCommand
+// error message to the Connection's writer.
+func (rs *StubServer) handleCommand(c *Connection, cmd string, args []string) {
+	rs.Lock()
+	handlerFn, ok := rs.handlers[cmd]
+	rs.Unlock()
+	if !ok {
+		c.WriteError(ErrUnknownCommand)
+		return
+	}
+
+	rs.Lock()
+	rs.processedCommands++
+	rs.Unlock()
+
+	handlerFn(c, args)
+}
+
+// Connection represents a client connection to the redis server.
+type Connection struct {
+	writer *bufio.Writer
+	reader *bufio.Reader
+	mutex  sync.Mutex
+}
+
+// NewConnection creates a new Connection from the provided
+// buffered reader and writer (usually a net.Conn instance).
+func NewConnection(r *bufio.Reader, w *bufio.Writer) *Connection {
+	return &Connection{
+		reader: r,
+		writer: w,
+	}
+}
+
+// ParseRequest parses a request from the Connection's reader.
+// It returns the parsed command, arguments and any error.
+func (c *Connection) ParseRequest() (string, []string, error) {
+	return NewRESPRequestReader(c.reader).ReadCommand()
+}
+
+// Flush flushes the Connection's writer, effectively sending
+// all buffered data to the client.
+func (c *Connection) Flush() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if err := c.writer.Flush(); err != nil {
+		// this is unrecoverable, so we panic.
+		panic(err)
+	}
+}
+
+// WriteSimpleString writes the provided value as a redis simple string message
+// to the Connection's writer.
+func (c *Connection) WriteSimpleString(s string) {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteSimpleString(s)
+	})
+}
+
+// WriteError writes the provided error as a redis error message
+// to the Connection's writer.
+func (c *Connection) WriteError(err error) {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteError(err)
+	})
+}
+
+// WriteInteger writes the provided integer as a redis integer message
+// to the Connection's writer.
+func (c *Connection) WriteInteger(i int) {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteInteger(i)
+	})
+}
+
+// WriteBulkString writes the provided string as a redis bulk string message
+// to the Connection's writer.
+func (c *Connection) WriteBulkString(s string) {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteBulkString(s)
+	})
+}
+
+// WriteArray writes the provided array of string as a redis array message
+// to the Connection's writer.
+func (c *Connection) WriteArray(arr ...string) {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteArray(arr...)
+	})
+}
+
+// WriteNull writes a redis Null message to the Connection's writer.
+func (c *Connection) WriteNull() {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteNull()
+	})
+}
+
+// WriteOK is a helper method for writing the OK response to the
+// Connection's writer.
+func (c *Connection) WriteOK() {
+	c.callFn(func(w *RESPResponseWriter) {
+		w.WriteSimpleString("OK")
+	})
+}
+
+// callFn calls the provided function in a locking manner.
+//
+// It is used to ensure that the Connection's writer is not
+// modified while it is being written to.
+func (c *Connection) callFn(fn func(*RESPResponseWriter)) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	fn(&RESPResponseWriter{c.writer})
+}
+
+// RESPRequestReader is a RESP protocol request reader.
+type RESPRequestReader struct {
+	reader *bufio.Reader
+}
+
+// NewRESPRequestReader returns a new RESPRequestReader.
+func NewRESPRequestReader(reader *bufio.Reader) *RESPRequestReader {
+	return &RESPRequestReader{reader: reader}
+}
+
+// ReadCommand reads a RESP command from the reader, parses it, and
+// returns the parsed command, args, and any potential error encountered.
+func (rrr *RESPRequestReader) ReadCommand() (string, []string, error) {
+	elements, err := scanArray(rrr.reader)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if len(elements) < 1 {
+		return "", nil, ErrInvalidSyntax
+	}
+
+	return strings.ToUpper(elements[0]), elements[1:], nil
+}
+
+// ErrInvalidSyntax is returned when a RESP protocol message
+// is malformed and cannot be parsed.
+var ErrInvalidSyntax = errors.New("invalid RESP protocol syntax")
+
+// Prefix is a placeholder type for the prefix symbol of
+// RESP response message.
+type Prefix byte
+
+// RESP protocol response type prefixes definitions
+const (
+	SimpleStringPrefix Prefix = '+'
+	ErrorPrefix               = '-'
+	IntegerPrefix             = ':'
+	BulkStringPrefix          = '$'
+	ArrayPrefix               = '*'
+	UnknownPrefix
+)
+
+// RESPResponseWriter is a RESP protocol response writer.
+type RESPResponseWriter struct {
+	writer *bufio.Writer
+}
+
+// WriteSimpleString writes a redis inline string
+func (rw *RESPResponseWriter) WriteSimpleString(s string) {
+	fmt.Fprintf(rw.writer, "+%s\r\n", inline(s))
+}
+
+// WriteError writes a redis 'Error'
+func (rw *RESPResponseWriter) WriteError(err error) {
+	fmt.Fprintf(rw.writer, "-%s\r\n", inline(err.Error()))
+}
+
+// WriteInteger writes an integer
+func (rw *RESPResponseWriter) WriteInteger(n int) {
+	fmt.Fprintf(rw.writer, ":%d\r\n", n)
+}
+
+// WriteBulkString writes a bulk string
+func (rw *RESPResponseWriter) WriteBulkString(s string) {
+	fmt.Fprintf(rw.writer, "$%d\r\n%s\r\n", len(s), s)
+}
+
+// WriteArray writes a list of strings (bulk)
+func (rw *RESPResponseWriter) WriteArray(strs ...string) {
+	rw.writeLen(len(strs))
+	for _, s := range strs {
+		if s == "" || s == "nil" {
+			rw.WriteNull()
+			continue
+		}
+
+		rw.WriteBulkString(s)
+	}
+}
+
+// WriteNull writes a redis Null element
+func (rw *RESPResponseWriter) WriteNull() {
+	fmt.Fprintf(rw.writer, "$-1\r\n")
+}
+
+func (rw *RESPResponseWriter) writeLen(n int) {
+	fmt.Fprintf(rw.writer, "*%d\r\n", n)
+}
+
+func inline(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return ' '
+		}
+		return r
+	}, s)
+}
+
+// scanBulkString reads a RESP bulk string message from a bufio.reader
+//
+// It also strips it from its prefix and trailing CRLF character, returning
+// only the interpretable content of the message.
+func scanBulkString(r *bufio.Reader) (string, error) {
+	line, err := scanLine(r)
+	if err != nil {
+		return "", err
+	}
+
+	switch Prefix(line[0]) {
+	case BulkStringPrefix:
+		length, err := strconv.Atoi(line[1 : len(line)-2])
+		if err != nil {
+			return "", err
+		}
+
+		if length < 0 {
+			return line, nil
+		}
+
+		buf := make([]byte, length+2)
+		for pos := 0; pos < length+2; {
+			n, err := r.Read(buf[pos:])
+			if err != nil {
+				return "", err
+			}
+
+			pos += n
+		}
+
+		return string(buf[:len(buf)-2]), nil
+	default:
+		return "", ErrInvalidSyntax
+	}
+}
+
+// scanArray reads a RESP array message from a bufio.Reader.
+//
+// It strips it from its prefix and trailing CRLF character,
+// returning only the interpretable content of the message.
+func scanArray(r *bufio.Reader) ([]string, error) {
+	line, err := scanLine(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(line) < 3 {
+		return nil, ErrInvalidSyntax
+	}
+
+	if Prefix(line[0]) != ArrayPrefix {
+		return nil, ErrInvalidSyntax
+	}
+
+	length, err := strconv.Atoi(line[1 : len(line)-2])
+	if err != nil {
+		return nil, err
+	}
+
+	var elements []string
+	for ; length > 0; length-- {
+		next, err := scanBulkString(r)
+		if err != nil {
+			return nil, err
+		}
+
+		elements = append(elements, next)
+	}
+
+	return elements, nil
+}
+
+// scanLine reads a RESP protocol line from a bufio.Reader.
+func scanLine(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	if len(line) < 3 {
+		return "", ErrInvalidSyntax
+	}
+
+	return line, nil
+}


### PR DESCRIPTION
## What

This PR adds integration tests covering the xk6-redis API with the goal to improve its stability and test coverage in preparation of merging it to k6's core. It attempts to test the extension in the context of a script interacting with a Redis instance, and focuses on testing the k6/goja/promises/event loop behavior of the `Client`, rather than interactions with Redis itself (considering we use a pre-established Redis library under the hood). In certain scenarios, we relied on a more extensive testing strategy in order to explicit the promise-based specific behavior of certain operations that might derive from Redis' behavior itself (rejecting a promise under certain conditions rather than returning zero, for instance).

Things that were left out of the scope of this PR: this PR doesn't test Redis in sentinel mode, nor in cluster mode. The feature should be supported out of the box, but I didn't get to address testing it, yet (if ever). 

## How

This PR is quite massive. Writing tests for an API as big as Redis' involves, well, lots of code. That was to be expected. However, the test file is organized as follows:
- Every `Client` command has its own `TestClient{Command}(` test function. They all follow the same convention, and the same approach, and should be somewhat similar. It's probably not worth reviewing ALL of them, but by reviewing a few of them, the pattern should become explicit, and you will likely be able to spot systemic mistakes and cases I might have missed. 
- Two table tests `TestClientCommandsAgainstUnreachableServer` and `TestClientCommandInInitContext` verify that, based on the fact that every command will ensure a connection is established under the hood, those should fail when ran against an unreachable host, or when executed in the init context.
- `Client.Connect`, `Client.Close` and private methods have been tested separately, and follow a bit of a different testing convention, and it might be reviewing those.

## Open questions and Feedback needed

### Connect and Close methods

Although the underlying [library](https://github.com/go-redis/redis) we used to implement the interactions with Redis does not require to explicitly establish a connection, we need to emulate that in the context of k6. The main reason for is that we want to avoid IO to happen in the init context of our users scripts. Besides, as we want our Redis client to reuse our VUs `Dialer` and `TLSConfig`, we need to wait for the VU `State` to be available before any connection to a Redis instance/cluster is attempted. As a result, I tackled this constraint by implementing explicit `Connect` and `Close` methods, as we seem to already have in other extensions/modules such as gRPC's. 

Our main design question is: as of today, every client's methods call connect under the hood, to make sure that the Redis client has an underlying client's instance, that is properly configured with the VU's `Dialer` and `TLSConfig`. I would like to hear your views on what design you'd prefer: **the user must explicitly call the `.connect` method in the init context, or we keep connecting under the hood automatically?**. 

### Testing approach

We've used an integration testing approach. To avoid importing extra-dependencies, we have developed a dedicated and externally controllable redis mock/stub server (in the spirit of `httptest`). Running this stub server, we run scripts directly into a test runtime, and assert the outcome directly in the script. Once the script is successfully run, we assert that our redis stub server received the commands we expected in the order we anticipated.

I probably have missed some failure scenarios, some edge cases, or dark corners of the script I'm not yet aware of, or have forgotten 🤷🏻 Please, check out some tests, and let me know if you can think of ways to break them, so I can improve the whole suite.

## Finally

Thank you for your time and attention! Please let me know what you think 🙇🏻 

## Edits

**26th of July 2022**: Removed mentions of miniredis in favor of the stub server. Explicated testing design strategy.