### PR TITLE
Remove double k6 module double registering

### DIFF
--- a/redis/module.go
+++ b/redis/module.go
@@ -14,12 +14,6 @@ import (
 	"go.k6.io/k6/js/modules"
 )
 
-// Register the extension on module initialization, available to
-// import from JS as "k6/x/redis".
-func init() {
-	modules.Register("k6/x/redis", New())
-}
-
 type (
 	// RootModule is the global module instance that will create Client
 	// instances for each VU.

--- a/register.go
+++ b/register.go
@@ -6,6 +6,8 @@ import (
 	"go.k6.io/k6/js/modules"
 )
 
+// Register the extension on module initialization, available to
+// import from JS as "k6/x/redis".
 func init() {
 	modules.Register("k6/x/redis", new(redis.RootModule))
 }


### PR DESCRIPTION
As a result of the previous module reorganization,
we had left a modules.Register statement behind
leading to a situation where the module itself would
end up registered twice, and would break any build
including xk6-redis.

This commit removes the left behind modules.Register
statement.