### PR TITLE
Refactor Client constructor options, add (m)TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Redis client library for [k6](https://github.com/grafana/k6),
 implemented as an extension using the [xk6](https://github.com/grafana/xk6) system.
 
-| :exclamation: This extension is under heavy development, and breaking changes are possible. USE AT YOUR OWN RISK! |
+| :exclamation: This extension is an experimental project, and breaking changes are possible. USE AT YOUR OWN RISK! |
 |-------------------------------------------------------------------------------------------------------------------|
 
 ## Build

--- a/examples/loadtest.js
+++ b/examples/loadtest.js
@@ -21,11 +21,11 @@ export const options = {
   },
 };
 
-// Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: __ENV.REDIS_ADDRS.split(",") || new Array("localhost:6379"), // in the form of "host:port", separated by commas
-  password: __ENV.REDIS_PASSWORD || "",
-});
+// Instantiate a new Redis client using a URL
+const redisClient = new redis.Client(
+  // URL in the form of redis[s]://[[username][:password]@][host][:port][/db-number
+  __ENV.REDIS_URL || "redis://localhost:6379",
+);
 
 // Prepare an array of crocodile ids for later use
 // in the context of the measureUsingRedisData function.

--- a/examples/tls/README.md
+++ b/examples/tls/README.md
@@ -1,0 +1,8 @@
+# How to run a k6 test against a Redis test server with TLS
+
+1. Move in the docker folder `cd docker`
+2. Run `sh gen-test-certs.sh` to generate custom TLS certificates that the docker container will use.
+3. Run `docker-compose up` to start the Redis server with TLS enabled.
+4. Connect to it with `redis-cli --tls --cert ./tests/tls/redis.crt --key ./tests/tls/redis.key --cacert ./tests/tls/ca.crt` and run `AUTH tjkbZ8jrwz3pGiku` to authenticate, and verify that the redis server is properly set up.
+5. Build the k6 binary with `xk6 build --with github.com/k6io/xk6-redis=.`
+5. Run `./k6 run loadtest-tls.js` to run the k6 load test with TLS enabled.

--- a/examples/tls/docker/docker-compose.yml
+++ b/examples/tls/docker/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.3"
+
+services:
+  redis:
+    image: docker.io/bitnami/redis:7.0.8
+    user: root
+    restart: always
+    environment:
+      - ALLOW_EMPTY_PASSWORD=false
+      - REDIS_PASSWORD=tjkbZ8jrwz3pGiku
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+      - REDIS_EXTRA_FLAGS=--loglevel verbose --tls-auth-clients optional
+      - REDIS_TLS_ENABLED=yes
+      - REDIS_TLS_PORT=6379
+      - REDIS_TLS_CERT_FILE=/tls/redis.crt
+      - REDIS_TLS_KEY_FILE=/tls/redis.key
+      - REDIS_TLS_CA_FILE=/tls/ca.crt
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/bitnami/redis/data
+      - ./tests/tls:/tls
+
+volumes:
+  redis_data:
+    driver: local

--- a/examples/tls/docker/gen-test-certs.sh
+++ b/examples/tls/docker/gen-test-certs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Generate some test certificates which are used by the regression test suite:
+#
+#   tests/tls/ca.{crt,key}          Self signed CA certificate.
+#   tests/tls/redis.{crt,key}       A certificate with no key usage/policy restrictions.
+#   tests/tls/client.{crt,key}      A certificate restricted for SSL client usage.
+#   tests/tls/server.{crt,key}      A certificate restricted for SSL server usage.
+#   tests/tls/redis.dh              DH Params file.
+
+generate_cert() {
+    local name=$1
+    local cn="$2"
+    local opts="$3"
+
+    local keyfile=tests/tls/${name}.key
+    local certfile=tests/tls/${name}.crt
+
+    [ -f $keyfile ] || openssl genrsa -out $keyfile 2048
+    openssl req \
+        -new -sha256 \
+        -subj "/O=Redis Test/CN=$cn" \
+        -key $keyfile |
+        openssl x509 \
+            -req -sha256 \
+            -CA tests/tls/ca.crt \
+            -CAkey tests/tls/ca.key \
+            -CAserial tests/tls/ca.txt \
+            -CAcreateserial \
+            -days 365 \
+            $opts \
+            -out $certfile
+}
+
+mkdir -p tests/tls
+[ -f tests/tls/ca.key ] || openssl genrsa -out tests/tls/ca.key 4096
+openssl req \
+    -x509 -new -nodes -sha256 \
+    -key tests/tls/ca.key \
+    -days 3650 \
+    -subj '/O=Redis Test/CN=Certificate Authority' \
+    -out tests/tls/ca.crt
+
+cat >tests/tls/openssl.cnf <<_END_
+[ server_cert ]
+keyUsage = digitalSignature, keyEncipherment
+nsCertType = server
+
+[ client_cert ]
+keyUsage = digitalSignature, keyEncipherment
+nsCertType = client
+_END_
+
+generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
+generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
+generate_cert redis "Generic-cert"
+
+[ -f tests/tls/redis.dh ] || openssl dhparam -out tests/tls/redis.dh 2048

--- a/examples/tls/loadtest-tls.js
+++ b/examples/tls/loadtest-tls.js
@@ -10,14 +10,14 @@ export const options = {
 // Instantiate a new Redis client using a URL
 // const client = new redis.Client('rediss://localhost:6379')
 const client = new redis.Client({
-    password: "password",
+    password: "tjkbZ8jrwz3pGiku",
     socket:{
         host: "localhost",
         port: 6379,
         tls: {
-            ca: [open('tests/tls/ca.crt')],
-            cert: open('tests/tls/client.crt'),  // client cert
-            key: open('tests/tls/client.key'),  // client private key
+            ca: [open('docker/tests/tls/ca.crt')],
+            cert: open('docker/tests/tls/client.crt'),  // client cert
+            key: open('docker/tests/tls/client.key'),  // client private key
         }
     }
 });

--- a/examples/tls/loadtest-tls.js
+++ b/examples/tls/loadtest-tls.js
@@ -1,0 +1,42 @@
+import redis from "k6/x/redis";
+import exec from "k6/execution";
+
+export const options = {
+    vus: 10,
+    iterations: 200,
+    insecureSkipTLSVerify: true,
+};
+
+// Instantiate a new Redis client using a URL
+// const client = new redis.Client('rediss://localhost:6379')
+const client = new redis.Client({
+    password: "password",
+    socket:{
+        host: "localhost",
+        port: 6379,
+        tls: {
+            ca: [open('tests/tls/ca.crt')],
+            cert: open('tests/tls/client.crt'),  // client cert
+            key: open('tests/tls/client.key'),  // client private key
+        }
+    }
+});
+
+export default async function () {
+    // VUs are executed in a parallel fashion,
+    // thus, to ensure that parallel VUs are not
+    // modifying the same key at the same time,
+    // we use keys indexed by the VU id.
+    const key = `foo-${exec.vu.idInTest}`;
+
+    await client.set(`foo-${exec.vu.idInTest}`, 1)
+
+    let value = await client.get(`foo-${exec.vu.idInTest}`)
+    value = await client.incrBy(`foo-${exec.vu.idInTest}`, value)
+    
+    await client.del(`foo-${exec.vu.idInTest}`)
+    const exists = await client.exists(`foo-${exec.vu.idInTest}`)
+    if (exists !== 0) {
+        throw new Error("foo should have been deleted");
+    }
+}

--- a/redis/client.go
+++ b/redis/client.go
@@ -1094,8 +1094,6 @@ func (c *Client) connect() error {
 			tlsCfg.KeyLogWriter = vuState.TLSConfig.KeyLogWriter
 
 			tlsCfg.Certificates = append(tlsCfg.Certificates, vuState.TLSConfig.Certificates...)
-			//nolint:staticcheck // ignore SA1019 This was deprecated, but k6 still supports it.
-			tlsCfg.NameToCertificate = vuState.TLSConfig.NameToCertificate
 
 			// TODO: Merge vuState.TLSConfig.RootCAs with
 			// c.redisOptions.TLSConfig. k6 currently doesn't allow setting

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -95,6 +95,20 @@ func TestClientConstructor(t *testing.T) {
 			}`,
 		},
 		{
+			name: "ok/object/sentinel",
+			arg: `{
+				username: 'user',
+				password: 'pass',
+				socket: {
+					host: 'localhost',
+					port: 6379,
+				},
+				masterName: 'masterhost',
+				sentinelUsername: 'sentineluser',
+				sentinelPassword: 'sentinelpass',
+			}`,
+		},
+		{
 			name:   "err/empty",
 			arg:    "",
 			expErr: "must specify one argument",

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -27,11 +27,72 @@ func TestClientConstructor(t *testing.T) {
 	}{
 		{
 			name: "ok/url/tcp",
-			arg:  "'redis://%s'",
+			arg:  "'redis://user:pass@localhost:6379/0'",
 		},
 		{
 			name: "ok/url/tls",
-			arg:  "'rediss://%s'",
+			arg:  "'rediss://somesecurehost'",
+		},
+		{
+			name: "ok/object/single",
+			arg: `{
+				clientName: 'myclient',
+				username: 'user',
+				password: 'pass',
+				socket: {
+					host: 'localhost',
+					port: 6379,
+				}
+			}`,
+		},
+		{
+			name: "ok/object/single_tls",
+			arg: `{
+				socket: {
+					host: 'localhost',
+					port: 6379,
+					tls: {
+						ca: ['...'],
+					}
+				}
+			}`,
+		},
+		{
+			name: "ok/object/cluster_urls",
+			arg: `{
+				cluster: {
+					maxRedirects: 3,
+					readOnly: true,
+					routeByLatency: true,
+					routeRandomly: true,
+					nodes: ['redis://host1:6379', 'redis://host2:6379']
+				}
+			}`,
+		},
+		{
+			name: "ok/object/cluster_objects",
+			arg: `{
+				cluster: {
+					nodes: [
+						{
+							username: 'user',
+							password: 'pass',
+							socket: {
+								host: 'host1',
+								port: 6379,
+							},
+						},
+						{
+							username: 'user',
+							password: 'pass',
+							socket: {
+								host: 'host2',
+								port: 6379,
+							},
+						}
+					]
+				}
+			}`,
 		},
 		{
 			name:   "err/empty",
@@ -40,18 +101,79 @@ func TestClientConstructor(t *testing.T) {
 		},
 		{
 			name:   "err/url/missing_scheme",
-			arg:    "'%s'",
-			expErr: "first path segment in URL cannot contain colon",
+			arg:    "'localhost:6379'",
+			expErr: "invalid URL scheme",
 		},
 		{
 			name:   "err/url/invalid_scheme",
-			arg:    "'https://%s'",
+			arg:    "'https://localhost:6379'",
 			expErr: "invalid options; reason: redis: invalid URL scheme: https",
 		},
 		{
 			name:   "err/object/unknown_field",
-			arg:    "{addrs: ['%s']}",
+			arg:    "{addrs: ['localhost:6379']}",
 			expErr: `invalid options; reason: json: unknown field "addrs"`,
+		},
+		{
+			name: "err/object/empty_socket",
+			arg: `{
+				username: 'user',
+				password: 'pass',
+			}`,
+			expErr: "invalid options; reason: empty socket options",
+		},
+		{
+			name: "err/object/cluster_wrong_type",
+			arg: `{
+				cluster: {
+					nodes: 1,
+				}
+			}`,
+			expErr: `invalid options; reason: cluster nodes property must be an array; got int64`,
+		},
+		{
+			name: "err/object/cluster_wrong_type_internal",
+			arg: `{
+				cluster: {
+					nodes: [1, 2],
+				}
+			}`,
+			expErr: `invalid options; reason: cluster nodes array must contain string or object elements; got int64`,
+		},
+		{
+			name: "err/object/cluster_empty",
+			arg: `{
+				cluster: {
+					nodes: []
+				}
+			}`,
+			expErr: `invalid options; reason: cluster nodes property cannot be empty`,
+		},
+		{
+			name: "err/object/cluster_inconsistent_option",
+			arg: `{
+				cluster: {
+					nodes: [
+						{
+							username: 'user1',
+							password: 'pass',
+							socket: {
+								host: 'host1',
+								port: 6379,
+							},
+						},
+						{
+							username: 'user2',
+							password: 'pass',
+							socket: {
+								host: 'host2',
+								port: 6379,
+							},
+						}
+					]
+				}
+			}`,
+			expErr: `invalid options; reason: inconsistent username option: user1 != user2`,
 		},
 	}
 
@@ -61,14 +183,9 @@ func TestClientConstructor(t *testing.T) {
 			t.Parallel()
 
 			ts := newTestSetup(t)
-			rs := RunT(t)
-
-			var arg string
-			if tc.arg != "" {
-				arg = fmt.Sprintf(tc.arg, rs.Addr())
-			}
+			script := fmt.Sprintf("new Client(%s);", tc.arg)
 			gotScriptErr := ts.ev.Start(func() error {
-				_, err := ts.rt.RunString(fmt.Sprintf("new Client(%s);", arg))
+				_, err := ts.rt.RunString(script)
 				return err
 			})
 			if tc.expErr != "" {

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -26,27 +26,32 @@ func TestClientConstructor(t *testing.T) {
 		name, arg, expErr string
 	}{
 		{
-			name: "ok/url",
+			name: "ok/url/tcp",
 			arg:  "'redis://%s'",
 		},
 		{
-			name: "ok/object",
-			arg:  "{addrs: ['%s']}",
+			name: "ok/url/tls",
+			arg:  "'rediss://%s'",
 		},
 		{
 			name:   "err/empty",
 			arg:    "",
-			expErr: "must specify one argument at <eval>:1:1(1)",
+			expErr: "must specify one argument",
 		},
 		{
-			name:   "err/url",
-			arg:    "'%s'", // missing scheme
-			expErr: "first path segment in URL cannot contain colon at <eval>:1:1(2)",
+			name:   "err/url/missing_scheme",
+			arg:    "'%s'",
+			expErr: "first path segment in URL cannot contain colon",
 		},
 		{
-			name:   "err/object",
-			arg:    "{addr: ['%s']}",
-			expErr: `invalid argument; reason: unable to decode options json: unknown field "addr" at <eval>:1:1(6)`,
+			name:   "err/url/invalid_scheme",
+			arg:    "'https://%s'",
+			expErr: "invalid options; reason: redis: invalid URL scheme: https",
+		},
+		{
+			name:   "err/object/unknown_field",
+			arg:    "{addrs: ['%s']}",
+			expErr: `invalid options; reason: json: unknown field "addrs"`,
 		},
 	}
 
@@ -100,9 +105,7 @@ func TestClientSet(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.set("existing_key", "new_value")
 				.then(res => { if (res !== "OK") { throw 'unexpected value for set result: ' + res } })
@@ -151,9 +154,7 @@ func TestClientGet(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.get("existing_key")
 				.then(res => { if (res !== "old_value") { throw 'unexpected value for get result: ' + res } })
@@ -197,9 +198,7 @@ func TestClientGetSet(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.getSet("existing_key", "new_value")
 				.then(res => { if (res !== "old_value") { throw 'unexpected value for getSet result: ' + res } })
@@ -240,9 +239,7 @@ func TestClientDel(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.del("key1", "key2", "nonexisting_key")
 				.then(res => { if (res !== 2) { throw 'unexpected value for del result: ' + res } })
@@ -280,9 +277,7 @@ func TestClientGetDel(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.getDel("existing_key")
 				.then(res => { if (res !== "old_value") { throw 'unexpected value for getDel result: ' + res } })
@@ -321,9 +316,7 @@ func TestClientExists(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.exists("existing_key", "nonexisting_key")
 				.then(res => { if (res !== 1) { throw 'unexpected value for exists result: ' + res } })
@@ -363,9 +356,7 @@ func TestClientIncr(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.incr("existing_key")
 				.then(res => { if (res !== 11) { throw 'unexpected value for existing key incr result: ' + res } })
@@ -414,9 +405,7 @@ func TestClientIncrBy(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.incrBy("existing_key", 10)
 				.then(res => { if (res !== 20) { throw 'unexpected value for incrBy result: ' + res } })
@@ -459,9 +448,7 @@ func TestClientDecr(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.decr("existing_key")
 				.then(res => { if (res !== 9) { throw 'unexpected value for decr result: ' + res } })
@@ -510,9 +497,7 @@ func TestClientDecrBy(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.decrBy("existing_key", 2)
 				.then(res => { if (res !== 8) { throw 'unexpected value for decrBy result: ' + res } })
@@ -556,9 +541,7 @@ func TestClientRandomKey(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.randomKey()
 				.then(
@@ -597,9 +580,7 @@ func TestClientMget(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.mget("existing_key", "non_existing_key")
 				.then(
@@ -643,9 +624,7 @@ func TestClientExpire(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.expire("expires_key", 10)
 				.then(res => { if (res !== true) { throw 'unexpected value for expire result: ' + res } })
@@ -686,9 +665,7 @@ func TestClientTTL(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.ttl("expires_key")
 				.then(res => { if (res !== 10) { throw 'unexpected value for expire result: ' + res } })
@@ -729,9 +706,7 @@ func TestClientPersist(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.persist("expires_key")
 				.then(res => { if (res !== true) { throw 'unexpected value for expire result: ' + res } })
@@ -775,9 +750,7 @@ func TestClientLPush(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.lpush("existing_list", "second", "first")
 				.then(res => { if (res !== 3) { throw 'unexpected value for lpush result: ' + res } })
@@ -821,9 +794,7 @@ func TestClientRPush(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.rpush("existing_list", "second", "third")
 				.then(res => { if (res !== 3) { throw 'unexpected value for rpush result: ' + res } })
@@ -866,9 +837,7 @@ func TestClientLPop(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.lpop("existing_list")
 				.then(res => { if (res !== "first") { throw 'unexpected value for lpop first result: ' + res } })
@@ -919,9 +888,7 @@ func TestClientRPop(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.rpop("existing_list")
 				.then(res => { if (res !== "second") { throw 'unexpected value for rpop result: ' + res }})
@@ -984,9 +951,7 @@ func TestClientLRange(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.lrange("existing_list", 0, 0)
 				.then(res => { if (res.length !== 1 || res[0] !== "first") { throw 'unexpected value for lrange result: ' + res }})
@@ -1050,9 +1015,7 @@ func TestClientLIndex(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.lindex("existing_list", 0)
 				.then(res => { if (res !== "first") { throw 'unexpected value for lindex result: ' + res } })
@@ -1110,9 +1073,7 @@ func TestClientClientLSet(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.lset("existing_list", 0, "new_first")
 				.then(res => { if (res !== "OK") { throw 'unexpected value for lset result: ' + res }})
@@ -1158,9 +1119,7 @@ func TestClientLrem(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.lrem("existing_list", 1, "first")
 				.then(() => redis.lrem("existing_list", 0, "second"))
@@ -1207,9 +1166,7 @@ func TestClientLlen(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.llen("existing_list")
 				.then(res => { if (res !== 3) { throw 'unexpected value for llen result: ' + res } })
@@ -1255,9 +1212,7 @@ func TestClientHSet(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hset("existing_hash", "key", "value")
 				.then(res => { if (res !== 1) { throw 'unexpected value for hset result: ' + res } })
@@ -1311,9 +1266,7 @@ func TestClientHsetnx(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hsetnx("existing_hash", "key", "value")
 				.then(res => { if (res !== true) { throw 'unexpected value for hsetnx result: ' + res } })
@@ -1357,9 +1310,7 @@ func TestClientHget(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hget("existing_hash", "foo")
 				.then(res => { if (res !== "bar") { throw 'unexpected value for hget result: ' + res } })
@@ -1403,9 +1354,7 @@ func TestClientHdel(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hdel("existing_hash", "foo")
 				.then(res => { if (res !== 1) { throw 'unexpected value for hdel result: ' + res } })
@@ -1449,9 +1398,7 @@ func TestClientHgetall(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hgetall("existing_hash")
 				.then(res => { if (typeof res !== "object" || res['foo'] !== 'bar') { throw 'unexpected value for hgetall result: ' + res } })
@@ -1495,9 +1442,7 @@ func TestClientHkeys(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hkeys("existing_hash")
 				.then(res => { if (res.length !== 1 || res[0] !== 'foo') { throw 'unexpected value for hkeys result: ' + res } })
@@ -1541,9 +1486,7 @@ func TestClientHvals(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hvals("existing_hash")
 				.then(res => { if (res.length !== 1 || res[0] !== 'bar') { throw 'unexpected value for hvals result: ' + res } })
@@ -1587,9 +1530,7 @@ func TestClientHlen(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hlen("existing_hash")
 				.then(res => { if (res !== 1) { throw 'unexpected value for hlen result: ' + res } })
@@ -1642,9 +1583,7 @@ func TestClientHincrby(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.hincrby("existing_hash", "foo", 1)
 				.then(res => { if (res !== 2) { throw 'unexpected value for hincrby result: ' + res } })
@@ -1695,9 +1634,7 @@ func TestClientSadd(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.sadd("existing_set", "bar")
 				.then(res => { if (res !== 1) { throw 'unexpected value for sadd result: ' + res } })
@@ -1748,9 +1685,7 @@ func TestClientSrem(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.srem("existing_set", "foo")
 				.then(res => { if (res !== 1) { throw 'unexpected value for srem result: ' + res } })
@@ -1802,9 +1737,7 @@ func TestClientSismember(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.sismember("existing_set", "foo")
 				.then(res => { if (res !== true) { throw 'unexpected value for sismember result: ' + res } })
@@ -1848,9 +1781,7 @@ func TestClientSmembers(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.smembers("existing_set")
 				.then(res => { if (res.length !== 2 || 'foo' in res || 'bar' in res) { throw 'unexpected value for smembers result: ' + res } })
@@ -1891,9 +1822,7 @@ func TestClientSrandmember(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.srandmember("existing_set")
 				.then(res => { if (res !== 'foo' && res !== 'bar') { throw 'unexpected value for srandmember result: ' + res} })
@@ -1937,9 +1866,7 @@ func TestClientSpop(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.spop("existing_set")
 				.then(res => { if (res !== 'foo' && res !== 'bar') { throw 'unexpected value for spop result: ' + res} })
@@ -1985,9 +1912,7 @@ func TestClientSendCommand(t *testing.T) {
 
 	gotScriptErr := ts.ev.Start(func() error {
 		_, err := ts.rt.RunString(fmt.Sprintf(`
-			const redis = new Client({
-				addrs: new Array("%s"),
-			});
+			const redis = new Client('redis://%s');
 
 			redis.sendCommand("sadd", "existing_set", "foo")
 				.then(res => { if (res !== 1) { throw 'unexpected value for sadd result: ' + res } })
@@ -2191,9 +2116,7 @@ func TestClientCommandsInInitContext(t *testing.T) {
 
 			gotScriptErr := ts.ev.Start(func() error {
 				_, err := ts.rt.RunString(fmt.Sprintf(`
-				const redis = new Client({
-					addrs: new Array("unreachable:42424"),
-				});
+				const redis = new Client('redis://unreachable:42424');
 
 				%s.then(res => { throw 'expected to fail when called in the init context' })
 			`, tc.statement))
@@ -2389,9 +2312,7 @@ func TestClientCommandsAgainstUnreachableServer(t *testing.T) {
 
 			gotScriptErr := ts.ev.Start(func() error {
 				_, err := ts.rt.RunString(fmt.Sprintf(`
-				const redis = new Client({
-					addrs: new Array("unreachable:42424"),
-				});
+				const redis = new Client('redis://unreachable:42424');
 
 				%s.then(res => { throw 'expected to fail when server is unreachable' })
 			`, tc.statement))

--- a/redis/module.go
+++ b/redis/module.go
@@ -2,14 +2,9 @@
 package redis
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"time"
 
 	"github.com/dop251/goja"
-	"github.com/redis/go-redis/v9"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
@@ -62,15 +57,15 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 // If the first argument is a string, it's parsed as a Redis URL, and a
 // single-node Client is used.
 // Otherwise, an object is expected, and depending on its properties:
-// 1. If the MasterName option is specified, a sentinel-backed FailoverClient is used.
-// 2. If the number of Addrs is two or more, a ClusterClient is used.
+// 1. If the masterName property is defined, a sentinel-backed FailoverClient is used.
+// 2. If the cluster property is defined, a ClusterClient is used.
 // 3. Otherwise, a single-node Client is used.
 //
 // To support being instantiated in the init context, while not
 // producing any IO, as it is the convention in k6, the produced
-// Client is initially configured, but in a disconnected state. In
-// order to connect to the configured target instance(s), the `.Connect`
-// should be called.
+// Client is initially configured, but in a disconnected state.
+// The connection is automatically established when using any of the Redis
+// commands exposed by the Client.
 func (mi *ModuleInstance) NewClient(call goja.ConstructorCall) *goja.Object {
 	rt := mi.vu.Runtime()
 
@@ -78,149 +73,16 @@ func (mi *ModuleInstance) NewClient(call goja.ConstructorCall) *goja.Object {
 		common.Throw(rt, errors.New("must specify one argument"))
 	}
 
-	var (
-		opts     *options
-		parseErr error
-	)
-	switch val := call.Arguments[0].Export().(type) {
-	case string:
-		opts, parseErr = newOptionsFromString(val)
-	case map[string]interface{}:
-		opts, parseErr = newOptionsFromObject(val)
-	default:
-		common.Throw(rt, fmt.Errorf("unknown argument type: %T; expected string or object", val))
-	}
-
-	if parseErr != nil {
-		common.Throw(rt, fmt.Errorf("invalid argument; reason: %w", parseErr))
-	}
-
-	redisOptions := &redis.UniversalOptions{
-		Protocol:         2,
-		Addrs:            opts.Addrs,
-		DB:               opts.DB,
-		Username:         opts.Username,
-		Password:         opts.Password,
-		SentinelUsername: opts.SentinelUsername,
-		SentinelPassword: opts.SentinelPassword,
-		MasterName:       opts.MasterName,
-		MaxRetries:       opts.MaxRetries,
-		MinRetryBackoff:  time.Duration(opts.MinRetryBackoff) * time.Millisecond,
-		MaxRetryBackoff:  time.Duration(opts.MaxRetryBackoff) * time.Millisecond,
-		DialTimeout:      time.Duration(opts.DialTimeout) * time.Millisecond,
-		ReadTimeout:      time.Duration(opts.ReadTimeout) * time.Millisecond,
-		WriteTimeout:     time.Duration(opts.WriteTimeout) * time.Millisecond,
-		PoolSize:         opts.PoolSize,
-		MinIdleConns:     opts.MinIdleConns,
-		ConnMaxLifetime:  time.Duration(opts.MaxConnAge) * time.Millisecond,
-		PoolTimeout:      time.Duration(opts.PoolTimeout) * time.Millisecond,
-		ConnMaxIdleTime:  time.Duration(opts.IdleTimeout) * time.Millisecond,
-		MaxRedirects:     opts.MaxRedirects,
-		ReadOnly:         opts.ReadOnly,
-		RouteByLatency:   opts.RouteByLatency,
-		RouteRandomly:    opts.RouteRandomly,
+	opts, err := readOptions(call.Arguments[0].Export())
+	if err != nil {
+		common.Throw(rt, err)
 	}
 
 	client := &Client{
 		vu:           mi.vu,
-		redisOptions: redisOptions,
+		redisOptions: opts,
 		redisClient:  nil,
 	}
 
 	return rt.ToValue(client).ToObject(rt)
-}
-
-type options struct {
-	// Either a single address or a seed list of host:port addresses
-	// of cluster/sentinel nodes.
-	Addrs []string `json:"addrs,omitempty"`
-
-	// Database to be selected after connecting to the server.
-	// Only used in single-node and failover modes.
-	DB int `json:"db,omitempty"`
-
-	// Use the specified Username to authenticate the current connection
-	// with one of the connections defined in the ACL list when connecting
-	// to a Redis 6.0 instance, or greater, that is using the Redis ACL system.
-	Username string `json:"username,omitempty"`
-
-	// Optional password. Must match the password specified in the
-	// requirepass server configuration option (if connecting to a Redis 5.0 instance, or lower),
-	// or the User Password when connecting to a Redis 6.0 instance, or greater,
-	// that is using the Redis ACL system.
-	Password string `json:"password,omitempty"`
-
-	SentinelUsername string `json:"sentinelUsername,omitempty"`
-	SentinelPassword string `json:"sentinelPassword,omitempty"`
-
-	MasterName string `json:"masterName,omitempty"`
-
-	MaxRetries      int   `json:"maxRetries,omitempty"`
-	MinRetryBackoff int64 `json:"minRetryBackoff,omitempty"`
-	MaxRetryBackoff int64 `json:"maxRetryBackoff,omitempty"`
-
-	DialTimeout  int64 `json:"dialTimeout,omitempty"`
-	ReadTimeout  int64 `json:"readTimeout,omitempty"`
-	WriteTimeout int64 `json:"writeTimeout,omitempty"`
-
-	PoolSize     int   `json:"poolSize,omitempty"`
-	MinIdleConns int   `json:"minIdleConns,omitempty"`
-	MaxConnAge   int64 `json:"maxConnAge,omitempty"`
-	PoolTimeout  int64 `json:"poolTimeout,omitempty"`
-	IdleTimeout  int64 `json:"idleTimeout,omitempty"`
-
-	MaxRedirects   int  `json:"maxRedirects,omitempty"`
-	ReadOnly       bool `json:"readOnly,omitempty"`
-	RouteByLatency bool `json:"routeByLatency,omitempty"`
-	RouteRandomly  bool `json:"routeRandomly,omitempty"`
-}
-
-// newOptionsFromObject validates and instantiates an options struct from its
-// map representation as exported from goja.Runtime.
-func newOptionsFromObject(argument map[string]interface{}) (*options, error) {
-	jsonStr, err := json.Marshal(argument)
-	if err != nil {
-		return nil, fmt.Errorf("unable to serialize options to JSON %w", err)
-	}
-
-	// Instantiate a JSON decoder which will error on unknown
-	// fields. As a result, if the input map contains an unknown
-	// option, this function will produce an error.
-	decoder := json.NewDecoder(bytes.NewReader(jsonStr))
-	decoder.DisallowUnknownFields()
-
-	var opts options
-	err = decoder.Decode(&opts)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode options %w", err)
-	}
-
-	return &opts, nil
-}
-
-// newOptionsFromString parses the expected URL into the internal options struct.
-func newOptionsFromString(url string) (*options, error) {
-	opts, err := redis.ParseURL(url)
-	if err != nil {
-		return nil, err
-	}
-
-	return &options{
-		Addrs:              []string{opts.Addr},
-		DB:                 opts.DB,
-		Username:           opts.Username,
-		Password:           opts.Password,
-		MaxRetries:         opts.MaxRetries,
-		MinRetryBackoff:    opts.MinRetryBackoff.Milliseconds(),
-		MaxRetryBackoff:    opts.MaxRetryBackoff.Milliseconds(),
-		DialTimeout:        opts.DialTimeout.Milliseconds(),
-		ReadTimeout:        opts.ReadTimeout.Milliseconds(),
-		WriteTimeout:       opts.WriteTimeout.Milliseconds(),
-		PoolSize:           opts.PoolSize,
-		MinIdleConns:       opts.MinIdleConns,
-		MaxConnAge:         opts.MaxConnAge.Milliseconds(),
-		PoolTimeout:        opts.PoolTimeout.Milliseconds(),
-		IdleTimeout:        opts.IdleTimeout.Milliseconds(),
-		IdleCheckFrequency: opts.IdleCheckFrequency.Milliseconds(),
-	}, nil
 }

--- a/redis/options.go
+++ b/redis/options.go
@@ -1,0 +1,339 @@
+package redis
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type singleNodeOptions struct {
+	Socket          *socketOptions `json:"socket,omitempty"`
+	Username        string         `json:"username,omitempty"`
+	Password        string         `json:"password,omitempty"`
+	Database        int            `json:"database,omitempty"`
+	MaxRetries      int            `json:"maxRetries,omitempty"`
+	MinRetryBackoff int64          `json:"minRetryBackoff,omitempty"`
+	MaxRetryBackoff int64          `json:"maxRetryBackoff,omitempty"`
+}
+
+type socketOptions struct {
+	Host               string      `json:"host,omitempty"`
+	Port               int         `json:"port,omitempty"`
+	TLS                *tlsOptions `json:"tls,omitempty"`
+	DialTimeout        int64       `json:"dialTimeout,omitempty"`
+	ReadTimeout        int64       `json:"readTimeout,omitempty"`
+	WriteTimeout       int64       `json:"writeTimeout,omitempty"`
+	PoolSize           int         `json:"poolSize,omitempty"`
+	MinIdleConns       int         `json:"minIdleConns,omitempty"`
+	MaxConnAge         int64       `json:"maxConnAge,omitempty"`
+	PoolTimeout        int64       `json:"poolTimeout,omitempty"`
+	IdleTimeout        int64       `json:"idleTimeout,omitempty"`
+	IdleCheckFrequency int64       `json:"idleCheckFrequency,omitempty"`
+}
+
+type tlsOptions struct {
+	CA   []byte `json:"ca,omitempty"`
+	Cert []byte `json:"cert,omitempty"`
+	Key  []byte `json:"key,omitempty"`
+}
+
+type commonClusterSentinelOptions struct {
+	MaxRedirects   int  `json:"maxRedirects,omitempty"`
+	ReadOnly       bool `json:"readOnly,omitempty"`
+	RouteByLatency bool `json:"routeByLatency,omitempty"`
+	RouteRandomly  bool `json:"routeRandomly,omitempty"`
+}
+
+type clusterNodesMapOptions struct {
+	commonClusterSentinelOptions
+	Nodes []*singleNodeOptions `json:"nodes,omitempty"`
+}
+
+type clusterNodesStringOptions struct {
+	commonClusterSentinelOptions
+	Nodes []string `json:"nodes,omitempty"`
+}
+
+type sentinelOptions struct {
+	singleNodeOptions
+	commonClusterSentinelOptions
+	MasterName string `json:"masterName,omitempty"`
+}
+
+// newOptionsFromObject validates and instantiates an options struct from its
+// map representation as exported from goja.Runtime.
+func newOptionsFromObject(obj map[string]interface{}) (*redis.UniversalOptions, error) {
+	var options interface{}
+	if cluster, ok := obj["cluster"].(map[string]interface{}); ok {
+		obj = cluster
+		switch cluster["nodes"].(type) {
+		case []interface{}:
+			options = &clusterNodesMapOptions{}
+		case []string:
+			options = &clusterNodesStringOptions{}
+		}
+	} else if _, ok := obj["masterName"]; ok {
+		options = &sentinelOptions{}
+	} else {
+		options = &singleNodeOptions{}
+	}
+
+	jsonStr, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize options to JSON %w", err)
+	}
+
+	// Instantiate a JSON decoder which will error on unknown
+	// fields. As a result, if the input map contains an unknown
+	// option, this function will produce an error.
+	decoder := json.NewDecoder(bytes.NewReader(jsonStr))
+	decoder.DisallowUnknownFields()
+
+	err = decoder.Decode(&options)
+	if err != nil {
+		return nil, err
+	}
+
+	return toUniversalOptions(options)
+}
+
+// newOptionsFromString parses the expected URL into redis.UniversalOptions.
+func newOptionsFromString(url string) (*redis.UniversalOptions, error) {
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return toUniversalOptions(opts)
+}
+
+func readOptions(options interface{}) (*redis.UniversalOptions, error) {
+	var (
+		opts *redis.UniversalOptions
+		err  error
+	)
+	switch val := options.(type) {
+	case string:
+		opts, err = newOptionsFromString(val)
+	case map[string]interface{}:
+		opts, err = newOptionsFromObject(val)
+	default:
+		return nil, fmt.Errorf("invalid options type: %T; expected string or object", val)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("invalid options; reason: %w", err)
+	}
+
+	return opts, nil
+}
+
+func toUniversalOptions(options interface{}) (*redis.UniversalOptions, error) {
+	var universalOpts *redis.UniversalOptions
+	switch o := options.(type) {
+	case *clusterNodesMapOptions:
+		universalOpts = &redis.UniversalOptions{
+			Protocol:       2,
+			MaxRedirects:   o.MaxRedirects,
+			ReadOnly:       o.ReadOnly,
+			RouteByLatency: o.RouteByLatency,
+			RouteRandomly:  o.RouteRandomly,
+		}
+		for _, n := range o.Nodes {
+			err := setConsistentOptions(universalOpts, n)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case *clusterNodesStringOptions:
+		universalOpts = &redis.UniversalOptions{
+			Protocol:       2,
+			MaxRedirects:   o.MaxRedirects,
+			ReadOnly:       o.ReadOnly,
+			RouteByLatency: o.RouteByLatency,
+			RouteRandomly:  o.RouteRandomly,
+		}
+		for _, n := range o.Nodes {
+			opts, err := redis.ParseURL(n)
+			if err != nil {
+				return nil, err
+			}
+			err = setConsistentOptionsRedis(universalOpts, opts)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case *sentinelOptions:
+	case *singleNodeOptions:
+		universalOpts = &redis.UniversalOptions{
+			Protocol:        2,
+			DB:              o.Database,
+			Username:        o.Username,
+			Password:        o.Password,
+			MaxRetries:      o.MaxRetries,
+			MinRetryBackoff: time.Duration(o.MinRetryBackoff) * time.Millisecond,
+			MaxRetryBackoff: time.Duration(o.MaxRetryBackoff) * time.Millisecond,
+		}
+		setSocketOptions(universalOpts, o.Socket)
+	case *redis.Options:
+		universalOpts = &redis.UniversalOptions{
+			Protocol:        2,
+			Addrs:           []string{o.Addr},
+			DB:              o.DB,
+			Username:        o.Username,
+			Password:        o.Password,
+			MaxRetries:      o.MaxRetries,
+			MinRetryBackoff: o.MinRetryBackoff,
+			MaxRetryBackoff: o.MaxRetryBackoff,
+			DialTimeout:     o.DialTimeout,
+			ReadTimeout:     o.ReadTimeout,
+			WriteTimeout:    o.WriteTimeout,
+			PoolSize:        o.PoolSize,
+			MinIdleConns:    o.MinIdleConns,
+			ConnMaxLifetime: o.ConnMaxLifetime,
+			PoolTimeout:     o.PoolTimeout,
+			ConnMaxIdleTime: o.ConnMaxIdleTime,
+		}
+	default:
+		panic(fmt.Sprintf("unexpected options type %T", options))
+	}
+
+	return universalOpts, nil
+}
+
+func setSocketOptions(opts *redis.UniversalOptions, sopts *socketOptions) {
+	opts.Addrs = []string{fmt.Sprintf("%s:%d", sopts.Host, sopts.Port)}
+	opts.DialTimeout = time.Duration(sopts.DialTimeout) * time.Millisecond
+	opts.ReadTimeout = time.Duration(sopts.ReadTimeout) * time.Millisecond
+	opts.WriteTimeout = time.Duration(sopts.WriteTimeout) * time.Millisecond
+	opts.PoolSize = sopts.PoolSize
+	opts.MinIdleConns = sopts.MinIdleConns
+	opts.ConnMaxLifetime = time.Duration(sopts.MaxConnAge) * time.Millisecond
+	opts.PoolTimeout = time.Duration(sopts.PoolTimeout) * time.Millisecond
+	opts.ConnMaxIdleTime = time.Duration(sopts.IdleTimeout) * time.Millisecond
+}
+
+// Set UniversalOption values from single-node options, ensuring that any
+// previously set values are consistent with the new values. This validates that
+// multiple node options set when using cluster mode are consistent with each other.
+// TODO: Use generics and/or reflection to DRY?
+func setConsistentOptions(uopts *redis.UniversalOptions, opts *singleNodeOptions) error {
+	uopts.Addrs = append(uopts.Addrs, fmt.Sprintf("%s:%d", opts.Socket.Host, opts.Socket.Port))
+
+	if uopts.DB != 0 && opts.Database != 0 && uopts.DB != opts.Database {
+		return fmt.Errorf("inconsistent db option: %d != %d", uopts.DB, opts.Database)
+	}
+	uopts.DB = opts.Database
+
+	if uopts.Username != "" && opts.Username != "" && uopts.Username != opts.Username {
+		return fmt.Errorf("inconsistent username option: %s != %s", uopts.Username, opts.Username)
+	}
+	uopts.Username = opts.Username
+
+	if uopts.Password != "" && opts.Password != "" && uopts.Password != opts.Password {
+		return fmt.Errorf("inconsistent password option")
+	}
+	uopts.Password = opts.Password
+
+	if uopts.MaxRetries != 0 && opts.MaxRetries != 0 && uopts.MaxRetries != opts.MaxRetries {
+		return fmt.Errorf("inconsistent maxRetries option: %d != %d", uopts.MaxRetries, opts.MaxRetries)
+	}
+	uopts.MaxRetries = opts.MaxRetries
+
+	if uopts.MinRetryBackoff != 0 && opts.MinRetryBackoff != 0 && uopts.MinRetryBackoff.Milliseconds() != opts.MinRetryBackoff {
+		return fmt.Errorf("inconsistent minRetryBackoff option: %d != %d", uopts.MinRetryBackoff.Milliseconds(), opts.MinRetryBackoff)
+	}
+	uopts.MinRetryBackoff = time.Duration(opts.MinRetryBackoff) * time.Millisecond
+
+	if uopts.MaxRetryBackoff != 0 && opts.MaxRetryBackoff != 0 && uopts.MaxRetryBackoff.Milliseconds() != opts.MaxRetryBackoff {
+		return fmt.Errorf("inconsistent maxRetryBackoff option: %d != %d", uopts.MaxRetryBackoff, opts.MaxRetryBackoff)
+	}
+	uopts.MaxRetryBackoff = time.Duration(opts.MaxRetryBackoff) * time.Millisecond
+
+	// TODO: Validate opts.Socket ...
+
+	return nil
+}
+
+// Set UniversalOption values from single-node options, ensuring that any
+// previously set values are consistent with the new values. This validates that
+// multiple node options set when using cluster mode are consistent with each other.
+// TODO: Use generics and/or reflection to DRY?
+func setConsistentOptionsRedis(uopts *redis.UniversalOptions, opts *redis.Options) error {
+	uopts.Addrs = append(uopts.Addrs, opts.Addr)
+
+	if uopts.DB != 0 && opts.DB != 0 && uopts.DB != opts.DB {
+		return fmt.Errorf("inconsistent db option: %d != %d", uopts.DB, opts.DB)
+	}
+	uopts.DB = opts.DB
+
+	if uopts.Username != "" && opts.Username != "" && uopts.Username != opts.Username {
+		return fmt.Errorf("inconsistent username option: %s != %s", uopts.Username, opts.Username)
+	}
+	uopts.Username = opts.Username
+
+	if uopts.Password != "" && opts.Password != "" && uopts.Password != opts.Password {
+		return fmt.Errorf("inconsistent password option")
+	}
+	uopts.Password = opts.Password
+
+	if uopts.MaxRetries != 0 && opts.MaxRetries != 0 && uopts.MaxRetries != opts.MaxRetries {
+		return fmt.Errorf("inconsistent maxRetries option: %d != %d", uopts.MaxRetries, opts.MaxRetries)
+	}
+	uopts.MaxRetries = opts.MaxRetries
+
+	if uopts.MinRetryBackoff != 0 && opts.MinRetryBackoff != 0 && uopts.MinRetryBackoff != opts.MinRetryBackoff {
+		return fmt.Errorf("inconsistent minRetryBackoff option: %d != %d", uopts.MinRetryBackoff, opts.MinRetryBackoff)
+	}
+	uopts.MinRetryBackoff = opts.MinRetryBackoff
+
+	if uopts.MaxRetryBackoff != 0 && opts.MaxRetryBackoff != 0 && uopts.MaxRetryBackoff != opts.MaxRetryBackoff {
+		return fmt.Errorf("inconsistent maxRetryBackoff option: %d != %d", uopts.MaxRetryBackoff, opts.MaxRetryBackoff)
+	}
+	uopts.MaxRetryBackoff = opts.MaxRetryBackoff
+
+	if uopts.DialTimeout != 0 && opts.DialTimeout != 0 && uopts.DialTimeout != opts.DialTimeout {
+		return fmt.Errorf("inconsistent dialTimeout option: %d != %d", uopts.DialTimeout, opts.DialTimeout)
+	}
+	uopts.DialTimeout = opts.DialTimeout
+
+	if uopts.ReadTimeout != 0 && opts.ReadTimeout != 0 && uopts.ReadTimeout != opts.ReadTimeout {
+		return fmt.Errorf("inconsistent readTimeout option: %d != %d", uopts.ReadTimeout, opts.ReadTimeout)
+	}
+	uopts.ReadTimeout = opts.ReadTimeout
+
+	if uopts.WriteTimeout != 0 && opts.WriteTimeout != 0 && uopts.WriteTimeout != opts.WriteTimeout {
+		return fmt.Errorf("inconsistent writeTimeout option: %d != %d", uopts.WriteTimeout, opts.WriteTimeout)
+	}
+	uopts.WriteTimeout = opts.WriteTimeout
+
+	if uopts.PoolSize != 0 && opts.PoolSize != 0 && uopts.PoolSize != opts.PoolSize {
+		return fmt.Errorf("inconsistent poolSize option: %d != %d", uopts.PoolSize, opts.PoolSize)
+	}
+	uopts.PoolSize = opts.PoolSize
+
+	if uopts.MinIdleConns != 0 && opts.MinIdleConns != 0 && uopts.MinIdleConns != opts.MinIdleConns {
+		return fmt.Errorf("inconsistent minIdleConns option: %d != %d", uopts.MinIdleConns, opts.MinIdleConns)
+	}
+	uopts.MinIdleConns = opts.MinIdleConns
+
+	if uopts.ConnMaxLifetime != 0 && opts.ConnMaxLifetime != 0 && uopts.ConnMaxLifetime != opts.ConnMaxLifetime {
+		return fmt.Errorf("inconsistent maxConnAge option: %d != %d", uopts.ConnMaxLifetime, opts.ConnMaxLifetime)
+	}
+	uopts.ConnMaxLifetime = opts.ConnMaxLifetime
+
+	if uopts.PoolTimeout != 0 && opts.PoolTimeout != 0 && uopts.PoolTimeout != opts.PoolTimeout {
+		return fmt.Errorf("inconsistent poolTimeout option: %d != %d", uopts.PoolTimeout, opts.PoolTimeout)
+	}
+	uopts.PoolTimeout = opts.PoolTimeout
+
+	if uopts.ConnMaxIdleTime != 0 && opts.ConnMaxIdleTime != 0 && uopts.ConnMaxIdleTime != opts.ConnMaxIdleTime {
+		return fmt.Errorf("inconsistent idleTimeout option: %d != %d", uopts.ConnMaxIdleTime, opts.ConnMaxIdleTime)
+	}
+	uopts.ConnMaxIdleTime = opts.ConnMaxIdleTime
+
+	return nil
+}

--- a/redis/options.go
+++ b/redis/options.go
@@ -81,7 +81,9 @@ type clusterNodesStringOptions struct {
 
 type sentinelOptions struct {
 	singleNodeOptions
-	MasterName string `json:"masterName,omitempty"`
+	MasterName       string `json:"masterName,omitempty"`
+	SentinelUsername string `json:"sentinelUsername,omitempty"`
+	SentinelPassword string `json:"sentinelPassword,omitempty"`
 }
 
 // newOptionsFromObject validates and instantiates an options struct from its
@@ -190,6 +192,17 @@ func toUniversalOptions(options interface{}) (*redis.UniversalOptions, error) {
 			}
 		}
 	case *sentinelOptions:
+		uopts.MasterName = o.MasterName
+		uopts.SentinelUsername = o.SentinelUsername
+		uopts.SentinelPassword = o.SentinelPassword
+
+		ropts, err := o.toRedisOptions()
+		if err != nil {
+			return nil, err
+		}
+		if err = setConsistentOptions(uopts, ropts); err != nil {
+			return nil, err
+		}
 	case *singleNodeOptions:
 		ropts, err := o.toRedisOptions()
 		if err != nil {

--- a/redis/tls_test.go
+++ b/redis/tls_test.go
@@ -1,0 +1,64 @@
+package redis
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// Generate self-signed TLS certificate and private key for testing purposes,
+// and return them as PEM encoded data.
+// Source: https://eli.thegreenplace.net/2021/go-https-servers-with-tls/
+func generateTLSCert() (certPEM, privateKeyPEM []byte, err error) {
+	pkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Grafana Labs"},
+		},
+		DNSNames:              []string{"localhost"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(3 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &pkey.PublicKey, pkey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if certPEM == nil {
+		return nil, nil, errors.New("failed to encode certificate to PEM")
+	}
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(pkey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	privateKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	if privateKeyPEM == nil {
+		return nil, nil, errors.New("failed to encode private key to PEM")
+	}
+
+	return certPEM, privateKeyPEM, nil
+}

--- a/redis/tls_test.go
+++ b/redis/tls_test.go
@@ -37,7 +37,7 @@ func generateTLSCert() (certPEM, privateKeyPEM []byte, err error) {
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(3 * time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 	}
 


### PR DESCRIPTION
This is a fix/feature implementation for #13.

It refactors the `Client` constructor to accept options that are better aligned with the Node Redis API, to increase familiarity with an established JS library, and to allow specifying (m)TLS options, as proposed [here](https://github.com/grafana/xk6-redis/issues/13#issuecomment-1614712626). This means that these are **breaking changes** for users of the previous API.

See the [updated README](https://github.com/grafana/xk6-redis/blob/feat/13-tls-refactor/README.md) and the tests for usage examples.

If you want to test this manually with a real Redis TLS server, see [this gist](https://gist.github.com/imiric/54da3cd8abaf1a2dbc159197636857fe) for instructions.

What's pending:
- [ ] There's a strange issue when using mTLS and the original example script, that causes Redis to abort with `ERR Protocol error: unauthenticated multibulk length`.
  I tracked it down to [this issue](https://github.com/StackExchange/StackExchange.Redis/issues/201), and [this comment](https://github.com/StackExchange/StackExchange.Redis/issues/201#issuecomment-98639005) mentions this being some `MSET` limitation. We use regular `SET` in the script, but maybe this is a general limitation of some kind(?). I'm not sure, but we'll need to look into it.
  According to [this other comment](https://github.com/mediocregopher/radix/issues/299#issuecomment-943190227), there's a nasty fix for this... :see_no_evil:
  UPDATE 2023-08-10: I haven't been able to reproduce this again, but we should be aware that it might be an issue to look into later.
- [x] General cleanup and DRYing.
- [x] Fix existing tests, and adding more.
- [x] Address all the TODOs, and feedback from this PR.
- [ ] Maybe split this PR into separate refactor and TLS changes PRs, but I wanted to leave them together as a draft for now.
  UPDATE 2023-08-10: I decided to leave it as a single PR, since the changes are closely related.