### PR TITLE
Fixes 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,6 @@ require (
 	gopkg.in/guregu/null.v3 v3.3.0
 )
 
-// To facilitate the integration of the extension in the k6 core codebase
-// we need to use the same version of the dependencies as k6.
-replace github.com/spf13/afero => github.com/spf13/afero v1.1.2
-
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -2573,9 +2573,6 @@ func newTestSetup(t testing.TB) testSetup {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
-	root, err := lib.NewGroup("", nil)
-	require.NoError(t, err)
-
 	samples := make(chan metrics.SampleContainer, 1000)
 
 	// We use self-signed TLS certificates for some tests, and need to disable
@@ -2585,7 +2582,6 @@ func newTestSetup(t testing.TB) testSetup {
 	tb.TLSClientConfig.InsecureSkipVerify = true
 
 	state := &lib.State{
-		Group:  root,
 		Dialer: tb.Dialer,
 		Options: lib.Options{
 			SystemTags: metrics.NewSystemTagSet(


### PR DESCRIPTION
One of the commits drop usage of removed API - that isn't  really needed.

The other removes a `replace` that isn't needed either - likely was due to some other dependency or some caching issue.