### PR TITLE
Remove direct dependency on guregu/null.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,6 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	go.k6.io/k6 v1.5.0
-
-	// To facilitate the integration of the extension in the k6 core codebase
-	// we need to use the same version of the dependencies as k6.
-	gopkg.in/guregu/null.v3 v3.3.0
 )
 
 require (
@@ -57,6 +53,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/guregu/null.v3 v3.3.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -16,7 +16,6 @@ import (
 	"go.k6.io/k6/lib/netext"
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/metrics"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestClientConstructor(t *testing.T) {
@@ -2574,7 +2573,6 @@ func newTestSetup(t testing.TB) testSetup {
 				metrics.TagStatus,
 				metrics.TagSubproto,
 			),
-			UserAgent: null.StringFrom("TestUserAgent"),
 		},
 		Samples:        ts.samples,
 		TLSConfig:      &tls.Config{},

--- a/redis/stub_test.go
+++ b/redis/stub_test.go
@@ -144,9 +144,7 @@ func (rs *StubServer) Start(secure bool, clientCert []byte) error {
 
 	rs.boundAddr = boundAddr
 
-	rs.waitGroup.Add(1)
-	go func() {
-		defer rs.waitGroup.Done()
+	rs.waitGroup.Go(func() {
 		rs.listenAndServe(listener)
 
 		rs.Lock()
@@ -154,7 +152,7 @@ func (rs *StubServer) Start(secure bool, clientCert []byte) error {
 			c.Close() //nolint:errcheck
 		}
 		rs.Unlock()
-	}()
+	})
 
 	// The redis-cli will always start a session by sending the
 	// COMMAND message.


### PR DESCRIPTION
## What?

Remove the direct dependency on `gopkg.in/guregu/null.v3`. The only usage was a single line in test setup that set `lib.Options.UserAgent` to a value the redis client never reads.

## Why?

This dependency was listed as a direct `require` with a comment about facilitating integration with k6 core. In practice, the only import was in `redis/client_test.go` to call `null.StringFrom("TestUserAgent")` — purely test boilerplate for a field the extension ignores.

Removing the direct usage moves it to `// indirect` in `go.mod` (it remains transitively via `go.k6.io/k6`). This reduces the number of direct dependencies from 5 to 4, which is a small step toward reducing Renovate PR noise across our extension repos.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.