### PR TITLE
chore: flatten Renovate config to extend k6-engine-base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["schedule:weekly"],
-  "packageRules": [
-    {
-      "description": "Disable updates for all dependencies by default",
-      "matchManagers": ["gomod"],
-      "enabled": false
-    },
-    {
-      "description": "k6 core and ecosystem packages",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["go.k6.io/k6/v2"],
-      "groupName": "k6 ecosystem",
-      "enabled": true
-    },
-    {
-      "description": "Redis library - critical for functionality",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["github.com/redis/go-redis/**"],
-      "enabled": true
-    }
+  "extends": [
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
   ]
 }


### PR DESCRIPTION
Aligns this repo's Renovate config with the rest of the k6 extensions by extending only the shared `github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json` preset.

Part of a broader k6 repo governance clean-up ([grafana/xk6](https://github.com/grafana/xk6)).