### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/examples/tls/docker/docker-compose.yml
+++ b/examples/tls/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   redis:
-    image: docker.io/bitnami/redis:7.0.8
+    image: docker.io/soldevelo/redis:7.0.15
     user: root
     restart: always
     environment:


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/redis:7.0.8` → [`soldevelo/redis:7.0.15`](https://hub.docker.com/r/soldevelo/redis)