### PR TITLE
chore(ci): update k6-ci to v0.4.0

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -14,4 +14,4 @@ permissions:
   
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@9477260e6838640d56c28aa95bcbf9a884ab21f3 # main
+    uses: grafana/k6-ci/.github/workflows/all.yml@777962b022a831166517639e542630d8b7d1455f # v0.4.0

--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -11,4 +11,4 @@ permissions:
   id-token: write
 jobs:
   approve:
-    uses: grafana/k6-ci/.github/workflows/auto-approve-renovate.yml@9477260e6838640d56c28aa95bcbf9a884ab21f3 # k6-ci#44 merge commit
+    uses: grafana/k6-ci/.github/workflows/auto-approve-renovate.yml@777962b022a831166517639e542630d8b7d1455f # v0.4.0


### PR DESCRIPTION
## Summary

Update grafana/k6-ci workflow references to v0.4.0 (777962b022a831166517639e542630d8b7d1455f).

## Changes

- Updated 2 workflow file(s).
- Updated 2 k6-ci reference(s).

## Testing

- Not run; this change only updates GitHub Actions references.
