### PR TITLE
Fix TLS SNI handling for Redis/Valkey cluster connections.

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -1150,8 +1150,17 @@ func (c *Client) upgradeDialerToTLS(dialer lib.DialContexter, config *tls.Config
 			return nil, err
 		}
 
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			host = addr
+		}
+
+		tlsConfig := config.Clone()
+		// Use the host of the individual Valkey node as TLS SNI.
+		tlsConfig.ServerName = host
+
 		// Upgrade the connection to TLS if needed
-		tlsConn := tls.Client(rawConn, config)
+		tlsConn := tls.Client(rawConn, tlsConfig)
 		err = tlsConn.HandshakeContext(ctx)
 		if err != nil {
 			if closeErr := rawConn.Close(); closeErr != nil {


### PR DESCRIPTION
fixes https://github.com/grafana/xk6-redis/issues/112


## What changed

* Derive the TLS `ServerName` from the hostname in the actual connection address (`addr`).
* Clone the existing `tls.Config` before modifying it.
* Set the per-node hostname as `tls.Config.ServerName`, so each Redis/Valkey cluster node uses its own hostname for TLS SNI.
* Handle invalid `host:port` addresses instead of silently ignoring `net.SplitHostPort` errors.

## Why

When using Redis/Valkey Cluster over TLS, the client may establish connections to different cluster nodes as a result of cluster topology discovery or `MOVED` responses.

Previously, the TLS connection could use an incorrect or missing SNI value, which can cause TLS routing or certificate validation failures when the backend requires SNI.

With this change, a connection such as:

```text
node-0.example.com:6379
```

uses:

```text
ServerName = node-0.example.com
```

and a connection to another shard/node automatically uses that node's hostname.

This is particularly useful for Valkey/Redis clusters behind an SNI-based TLS endpoint.